### PR TITLE
Listeners are now registered and removed based on elementId

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This hook fires whenever the `Component` leaves the viewport.
 ### Advanced usage (options)
 The mixin comes with some options:
 
-- `viewportSpy: boolean` (Does not work properly: See [issues](#issues))
+- `viewportSpy: boolean` (Only works when not in `rAF` mode: See [issues](#issues))
 
   Default: `false`
 
@@ -59,7 +59,7 @@ The main issue at the moment is with unbinding listeners and clearing the `reque
 
 - [ ] `_unbindListeners()` should clear the instance of the `requestAnimationFrame` recursion (per Object), but still remain performant
   - Currently, this method does not clear the `requestAnimationFrame` recursion when it is called. `cancelAnimationFrame` requires the `id` returned by the `requestAnimationFrame` method, but storing it in the Ember.Object causes severe memory issues (as it is being updated at 60FPS, or about every 16ms)
-- [ ] `_unbindListeners()` should clear the instance of the event listeners per element
+- [x] `_unbindListeners()` should clear the instance of the event listeners per element
   - This method clears all event listeners on the `window` and `document` (in reality, this mixin has only 3 listeners regardless of the number of `Components`, because of the way Ember registers event listeners globally), which means if you have >1 `Component` to watch, after one enters the viewport, it unbinds listeners for all other `Components`, whether or not they have entered the viewport.
 
 ## Installation

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -137,6 +137,8 @@ export default Ember.Mixin.create({
     Ember.assert('You must pass a valid event to _bindListeners', event);
 
     const elementId = get(this, 'elementId');
+    Ember.warn('No elementId was registered on this Object, viewportSpy will' +
+      'most likely not work as expected', elementId);
 
     $(context).on(event + elementId, () => {
       this._scrollHandler(context);
@@ -145,6 +147,8 @@ export default Ember.Mixin.create({
 
   _unbindListeners() {
     const elementId = get(this, 'elementId');
+    Ember.warn('No elementId was registered on this Object, viewportSpy will' +
+      'most likely not work as expected', elementId);
 
     forEach(listeners, (listener) => {
       const { context, event } = listener;

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -136,15 +136,19 @@ export default Ember.Mixin.create({
     Ember.assert('You must pass a valid context to _bindListeners', context);
     Ember.assert('You must pass a valid event to _bindListeners', event);
 
-    $(context).on(event, () => {
+    const elementId = get(this, 'elementId');
+
+    $(context).on(event + elementId, () => {
       this._scrollHandler(context);
     });
   },
 
   _unbindListeners() {
+    const elementId = get(this, 'elementId');
+
     forEach(listeners, (listener) => {
       const { context, event } = listener;
-      $(context).off(event);
+      $(context).off(event + elementId);
     });
   }
 });


### PR DESCRIPTION
Closes #1 

This commit allows each Ember.Object that the Mixin is extended with to
register their own instance of event listeners on the window and/or
document. This means `viewportSpy` will now work when the run loop fall
back is active.