### PR TITLE
Don't re-export mixins/utils in app tree

### DIFF
--- a/app/mixins/in-viewport.js
+++ b/app/mixins/in-viewport.js
@@ -1,3 +1,0 @@
-import InViewportMixin from 'ember-in-viewport/mixins/in-viewport';
-
-export default InViewportMixin;

--- a/app/utils/can-use-dom.js
+++ b/app/utils/can-use-dom.js
@@ -1,3 +1,0 @@
-import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
-
-export default canUseDOM;

--- a/app/utils/can-use-raf.js
+++ b/app/utils/can-use-raf.js
@@ -1,3 +1,0 @@
-import canUseRaf from 'ember-in-viewport/utils/can-use-raf';
-
-export default canUseRaf;

--- a/app/utils/is-in-viewport.js
+++ b/app/utils/is-in-viewport.js
@@ -1,3 +1,0 @@
-import IsInViewport from 'ember-in-viewport/utils/is-in-viewport';
-
-export default IsInViewport;

--- a/tests/unit/mixins/in-viewport-test.js
+++ b/tests/unit/mixins/in-viewport-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import InViewportMixin from '../../../mixins/in-viewport';
+import InViewportMixin from 'ember-in-viewport/mixins/in-viewport';
 import { module, test } from 'qunit';
 
 module('InViewportMixin');

--- a/tests/unit/utils/is-in-viewport-test.js
+++ b/tests/unit/utils/is-in-viewport-test.js
@@ -1,4 +1,4 @@
-import isInViewport from '../../../utils/is-in-viewport';
+import isInViewport from 'ember-in-viewport/utils/is-in-viewport';
 import { module, test } from 'qunit';
 
 let fakeRectNotInViewport, fakeRectInViewport, fakeWindow, fakeNoTolerance, fakeTolerance;


### PR DESCRIPTION
This commit removes the mixins and utils directories from the app tree,
as we should prefer importing directly from ember-in-viewport as opposed
to being relative to their app.

- Closes #5. Thanks to @rwjblue for reporting this