### PR TITLE
General refactor, fire Evented hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,34 @@ export default Ember.Component.extend(InViewportMixin, {
 
 ### Basic usage
 #### Available hooks
+##### `didEnterViewport`, `didExitViewport`
+These hooks fire once whenever the `Component` enters or exits the viewport. You can handle them the same way you would handle any other native Ember hook:
+
+```js
+export default Ember.Component.extend(InViewportMixin, {
+
+  // with prototype extensions disabled
+  handleDidEnterViewport: on('didEnterViewport', function() {
+    console.log('entered');
+  }),
+
+  handleDidExitViewport: on('didExitViewport', function() {
+    console.log('exited');
+  }),
+
+  // with prototype extensions enabled
+  didEnterViewport() {
+    console.log('entered');
+  },
+
+  didExitViewport() {
+    console.log('exited');
+  }
+});
+```
+
 ##### `viewportEntered`
-This hook fires whenever the `Component` enters the viewport. To apply an `.active` class to your `Component` when it enters the viewport, you can simply bind the `active` class to the mixed in property `viewportEntered`, like so:
+To apply an `.active` class to your `Component` when it enters the viewport, you can simply bind the `active` class to the mixed in property `viewportEntered`, like so:
 
 ```js
 export default Ember.Component.extend(InViewportMixin, {

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ These hooks fire once whenever the `Component` enters or exits the viewport. You
 export default Ember.Component.extend(InViewportMixin, {
 
   // with prototype extensions disabled
-  handleDidEnterViewport: on('didEnterViewport', function() {
+  handleDidEnterViewport: Ember.on('didEnterViewport', function() {
     console.log('entered');
   }),
 
-  handleDidExitViewport: on('didExitViewport', function() {
+  handleDidExitViewport: Ember.on('didExitViewport', function() {
     console.log('exited');
   }),
 

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -80,8 +80,9 @@ export default Ember.Mixin.create({
     const viewportTolerance  = get(this, 'viewportTolerance');
     const elementId          = get(this, 'elementId');
     const boundingClientRect = get(this, 'element').getBoundingClientRect();
-    const height             = $(context) ? $(context).height() : 0;
-    const width              = $(context) ? $(context).width()  : 0;
+    const contextEl          = $(context);
+    const height             = contextEl.height();
+    const width              = contextEl.width();
 
     this._triggerDidEnterViewport(
       isInViewport(boundingClientRect, height, width, viewportTolerance)


### PR DESCRIPTION
Closes #7. This commit is a general refactor of the Mixin for performance improvements. The Mixin now fires actual 'hooks', named `didEnterViewport` and `didExitViewport`, which you can use in your app in place of observers. For example,

```js
export default Ember.Component.extend(InViewportMixin, {
  handleDidEnterViewport: on('didEnterViewport', function() {
    console.log('entered');
  }),

  handleDidExitViewport: on('didExitViewport', function() {
    console.log('exited');
  })
});
```

Full changelog:

- refactored `_setViewportEntered`
- now triggers Events
- removed unnecessary Ember.warn
- updated debounce method to use fat arrow
- explicitly set `viewportEntered` when removing viewportSpy to prevent race conditions setting it to false
- renamed `_viewportDidEnter` to `_unbindIfEntered` which is more correct semantically
- removed unnecessary var declaration
- removed redundant initial call to `_setViewportEntered`
- removed $viewportCachedEl in favour of using `get(this, 'element')`