### PR TITLE
Initial implementation of waypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ export default Ember.Component.extend(InViewportMixin, {
 });
 ```
 
+##### [BETA] `didScroll{Up,Down,Left,Right}`
+The appropriate scroll hook fires when an element enters the viewport. For example, if you scrolled down in order to move the element in the viewport, the `didScrollDown` hook would fire. You can then handle it like another hook as in the above example.
+
+```js
+export default Ember.Component.extend(InViewportMixin, {
+  didScrollUp() {
+    console.log('up');
+  },
+
+  didScrollDown() {
+    console.log('down');
+  },
+
+  didScrollLeft() {
+    console.log('left');
+  },
+
+  didScrollRight() {
+    console.log('right');
+  }
+});
+```
+
 ##### `viewportEntered`
 To apply an `.active` class to your `Component` when it enters the viewport, you can simply bind the `active` class to the mixed in property `viewportEntered`, like so:
 

--- a/addon/utils/can-use-raf.js
+++ b/addon/utils/can-use-raf.js
@@ -26,7 +26,7 @@ function checkRAF(window, rAF, cAF) {
 }
 
 
-export default function canUseRaf() {
+export default function canUseRAF() {
   if (!canUseDOM) { return false; }
 
   return checkRAF(window, 'requestAnimationFrame', 'cancelAnimationFrame');

--- a/addon/utils/check-scroll-direction.js
+++ b/addon/utils/check-scroll-direction.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+const { floor } = Math;
+
+export default function checkScrollDirection(lastPosition = null, newPosition = {}, sensitivity = 1) {
+  if (!lastPosition) { return 'none'; }
+
+  Ember.assert('sensitivity cannot be 0', sensitivity);
+
+  const { top, left } = newPosition;
+  const { top: lastTop, left: lastLeft } = lastPosition;
+
+  const delta = {
+    top  : floor((top  - lastTop)  / sensitivity) * sensitivity,
+    left : floor((left - lastLeft) / sensitivity) * sensitivity
+  };
+
+  if (delta.top  > 0) { return 'down'; }
+  if (delta.top  < 0) { return 'up'; }
+  if (delta.left > 0) { return 'right'; }
+  if (delta.left < 0) { return 'left'; }
+}

--- a/addon/utils/is-in-viewport.js
+++ b/addon/utils/is-in-viewport.js
@@ -9,7 +9,7 @@ const defaultTolerance = {
   right  : 0
 };
 
-export default function isInViewport(boundingClientRect={}, height=0, width=0, tolerance=defaultTolerance) {
+export default function isInViewport(boundingClientRect = {}, height = 0, width = 0, tolerance = defaultTolerance) {
   const { top, left, bottom, right } = boundingClientRect;
   const tolerances = merge(defaultTolerance, tolerance);
   const {

--- a/tests/unit/utils/check-scroll-direction-test.js
+++ b/tests/unit/utils/check-scroll-direction-test.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+import checkScrollDirection from 'ember-in-viewport/utils/check-scroll-direction';
+import { module, test } from 'qunit';
+
+let lastPosition;
+
+const { forEach } = Ember.EnumerableUtils;
+
+module('checkScrollDirection', {
+  beforeEach() {
+    lastPosition = {
+      top  : 300,
+      left : 150
+    };
+  }
+});
+
+test('returns the right direction', function(assert) {
+  const movements = [
+    { direction: 'down',  position: { top: 400, left: 150 }},
+    { direction: 'up',    position: { top: 200, left: 150 }},
+    { direction: 'right', position: { top: 300, left: 250 }},
+    { direction: 'left',  position: { top: 300, left: 100 }}
+  ];
+
+  assert.expect(movements.length);
+
+  forEach(movements, (movement) => {
+    const { direction, position } = movement;
+    const scrollDirection = checkScrollDirection(lastPosition, position);
+
+    assert.equal(direction, scrollDirection);
+  });
+});
+
+test('adjusts for sensitivity', function(assert) {
+  const movements = [
+    { direction: undefined, position: { top: 399, left: 150 }},
+    { direction: 'down',    position: { top: 400, left: 150 }},
+    { direction: 'down',    position: { top: 500, left: 250 }}
+  ];
+
+  assert.expect(movements.length);
+
+  forEach(movements, (movement) => {
+    const { direction, position } = movement;
+    const scrollDirection = checkScrollDirection(lastPosition, position, 100);
+
+    assert.equal(direction, scrollDirection);
+  });
+});


### PR DESCRIPTION
First pass at getting hooks setup for a waypoints implementation. The goal is to replace the third party `waypoints` library used in `ember-waypoints` with an ember-addon. It isn't very optimized yet, but functionally ready.

Addresses #9. 