### PR TITLE
Guard against removed element

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -85,10 +85,13 @@ export default Ember.Mixin.create({
     const viewportUseRAF     = get(this, 'viewportUseRAF');
     const viewportTolerance  = get(this, 'viewportTolerance');
     const elementId          = get(this, 'elementId');
-    const boundingClientRect = get(this, 'element').getBoundingClientRect();
+    const element            = get(this, 'element');
     const $contextEl         = $(context);
     const height             = $contextEl.height();
     const width              = $contextEl.width();
+
+    if (!element) { return; }
+    const boundingClientRect = element.getBoundingClientRect();
 
     this._triggerDidEnterViewport(
       isInViewport(boundingClientRect, height, width, viewportTolerance)


### PR DESCRIPTION
Without this guard my tests were failing as `element` was `null` some times. most likely because it was already removed from dem DOM because I destroyed the App in the afterEach-hook of a test.