### PR TITLE
Set `viewportEntered` before triggering the `didEnterViewport` hook.

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -152,9 +152,9 @@ export default Ember.Mixin.create({
       triggeredEventName = 'didExitViewport';
     }
 
-    this.trigger(triggeredEventName);
-
     set(this, 'viewportEntered', hasEnteredViewport);
+
+    this.trigger(triggeredEventName);
   },
 
   _unbindIfEntered() {


### PR DESCRIPTION
This prevents an issue where `viewportEntered` would be `false` when
`didEnterViewport` fires, and vice versa.

Closes #16