### PR TITLE
Set default value for `viewportConfig`.

### DIFF
--- a/app/initializers/viewport-config.js
+++ b/app/initializers/viewport-config.js
@@ -1,7 +1,7 @@
 import config from '../config/environment';
 
 export function initialize(_container, application) {
-  const { viewportConfig } = config;
+  const { viewportConfig = {} } = config;
 
   application.register('config:in-viewport', viewportConfig, { instantiate: false });
 }


### PR DESCRIPTION
Prevents an error when `viewportConfig` is not defined in the app's
config.

Closes #15.