### PR TITLE
Move default config to initializer.

### DIFF
--- a/app/initializers/viewport-config.js
+++ b/app/initializers/viewport-config.js
@@ -1,9 +1,27 @@
+import Ember from 'ember';
 import config from '../config/environment';
+
+const defaultConfig = {
+  viewportSpy               : false,
+  viewportScrollSensitivity : 1,
+  viewportRefreshRate       : 100,
+  viewportListeners         : [],
+  viewportTolerance: {
+    top    : 0,
+    left   : 0,
+    bottom : 0,
+    right  : 0
+  }
+};
+
+const { merge } = Ember;
 
 export function initialize(_container, application) {
   const { viewportConfig = {} } = config;
 
-  application.register('config:in-viewport', viewportConfig, { instantiate: false });
+  const mergedConfig = merge(defaultConfig, viewportConfig);
+
+  application.register('config:in-viewport', mergedConfig, { instantiate: false });
 }
 
 export default {

--- a/config/environment.js
+++ b/config/environment.js
@@ -3,18 +3,5 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return {
-    viewportConfig: {
-      viewportSpy               : false,
-      viewportScrollSensitivity : 1,
-      viewportRefreshRate       : 100,
-      viewportListeners         : [],
-      viewportTolerance: {
-        top    : 0,
-        left   : 0,
-        bottom : 0,
-        right  : 0
-      },
-    }
-  };
+  return {};
 };


### PR DESCRIPTION
This prevents an issue where a consuming app's config would not be
deeply merged with the default config, which would make some props
undefined.

Closes #19.