### PR TITLE
Remove EnumerableUtils for Ember 2.0

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -27,7 +27,6 @@ const {
 } = run;
 
 const { not } = computed;
-const { forEach } = Ember.EnumerableUtils;
 const { classify } = Ember.String;
 
 const defaultListeners = [
@@ -72,7 +71,7 @@ export default Ember.Mixin.create({
     const listeners = get(this, 'viewportListeners');
 
     if (!get(this, 'viewportUseRAF')) {
-      forEach(listeners, (listener) => {
+      listeners.forEach((listener) => {
         const { context, event } = listener;
         this._bindListeners(context, event);
       });
@@ -228,7 +227,7 @@ export default Ember.Mixin.create({
       });
     }
 
-    forEach(listeners, (listener) => {
+    listeners.forEach((listener) => {
       const { context, event } = listener;
       $(context).off(`${event}.${elementId}`);
     });
@@ -239,7 +238,7 @@ export default Ember.Mixin.create({
   _deprecateOldTriggers() {
     const directions = [ 'Up', 'Down', 'Left', 'Right' ];
 
-    forEach(directions, (direction) => {
+    directions.forEach((direction) => {
       const triggerName = `didScroll${direction}`;
       const isListening = this.has(triggerName);
       deprecate(

--- a/tests/unit/utils/check-scroll-direction-test.js
+++ b/tests/unit/utils/check-scroll-direction-test.js
@@ -4,8 +4,6 @@ import { module, test } from 'qunit';
 
 let lastPosition;
 
-const { forEach } = Ember.EnumerableUtils;
-
 module('checkScrollDirection', {
   beforeEach() {
     lastPosition = {
@@ -25,7 +23,7 @@ test('returns the right direction', function(assert) {
 
   assert.expect(movements.length);
 
-  forEach(movements, (movement) => {
+  movements.forEach((movement) => {
     const { direction, position } = movement;
     const scrollDirection = checkScrollDirection(lastPosition, position);
 
@@ -42,7 +40,7 @@ test('adjusts for sensitivity', function(assert) {
 
   assert.expect(movements.length);
 
-  forEach(movements, (movement) => {
+  movements.forEach((movement) => {
     const { direction, position } = movement;
     const scrollDirection = checkScrollDirection(lastPosition, position, 100);
 


### PR DESCRIPTION
Ember 2.0 has removed EnumerableUtils causing ember-in-viewport to fail