### PR TITLE
Fix compatibility issue with apps that do not use an es6 transpiler

### DIFF
--- a/app/initializers/viewport-config.js
+++ b/app/initializers/viewport-config.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
 import config from '../config/environment';
 
-const defaultConfig = {
+// Note: this file must be es5-only in order to be compatible with apps that do
+// not use an es6 transpiler
+// jscs:disable
+var defaultConfig = {
   viewportSpy               : false,
   viewportScrollSensitivity : 1,
   viewportRefreshRate       : 100,
@@ -14,12 +17,12 @@ const defaultConfig = {
   }
 };
 
-const { merge } = Ember;
+var merge = Ember.merge;
 
 export function initialize(_container, application) {
-  const { viewportConfig = {} } = config;
+  var viewportConfig = config.viewportConfig || {};
 
-  const mergedConfig = merge(defaultConfig, viewportConfig);
+  var mergedConfig = merge(defaultConfig, viewportConfig);
 
   application.register('config:in-viewport', mergedConfig, { instantiate: false });
 }
@@ -28,3 +31,4 @@ export default {
   name: 'viewport-config',
   initialize: initialize
 };
+// jscs:enable


### PR DESCRIPTION
Since the [app initializer](https://github.com/dockyard/ember-in-viewport/blob/develop/app/initializers/viewport-config.js) is located in the `app/` dir, it gets included in the consuming application's app tree. If that app does not use an es6 transpiler, the initializer code will get passed straight through and end up breaking in the browser.

This PR just reverts to es5 compatible syntax in the initializer. Another option would be moving the initializer to the `addon/` dir and importing, but referencing the app's config becomes a pain.

I assume that PRs should target the `develop` branch, let me know if I should target `master` and I'll reopen a new one.

Thanks!
