### PR TITLE
Fix deprecation warning and faulty defaults

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -16,14 +16,9 @@ const {
   run: { scheduleOnce, debounce, bind, next },
   computed: { not }
 } = Ember;
-const defaultListeners = [
-  { context: window, event: 'scroll.scrollable' },
-  { context: window, event: 'resize.resizable' },
-  { context: document, event: 'touchmove.scrollable' }
-];
 const rAFIDS = {};
 const lastDirection = {};
-const lastPosition  = {};
+const lastPosition = {};
 
 export default Mixin.create({
   viewportExited: not('viewportEntered').readOnly(),
@@ -32,8 +27,7 @@ export default Mixin.create({
     this._super(...arguments);
     const options = merge({
       viewportUseRAF: canUseRAF(),
-      viewportEntered: false,
-      viewportListeners: defaultListeners
+      viewportEntered: false
     }, this._buildOptions());
 
     setProperties(this, options);
@@ -131,10 +125,6 @@ export default Mixin.create({
     const didEnter = !viewportEntered && hasEnteredViewport;
     const didLeave = viewportEntered && !hasEnteredViewport;
     let triggeredEventName = '';
-
-    if (!didEnter && !didLeave) {
-      return;
-    }
 
     if (didEnter) {
       triggeredEventName = 'didEnterViewport';

--- a/addon/utils/check-scroll-direction.js
+++ b/addon/utils/check-scroll-direction.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 
+const { assert } = Ember;
 const { floor } = Math;
 
 export default function checkScrollDirection(lastPosition = null, newPosition = {}, sensitivity = 1) {
@@ -7,7 +8,7 @@ export default function checkScrollDirection(lastPosition = null, newPosition = 
     return 'none';
   }
 
-  Ember.assert('sensitivity cannot be 0', sensitivity);
+  assert('sensitivity cannot be 0', sensitivity);
 
   const { top, left } = newPosition;
   const { top: lastTop, left: lastLeft } = lastPosition;
@@ -17,11 +18,11 @@ export default function checkScrollDirection(lastPosition = null, newPosition = 
     left: floor((left - lastLeft) / sensitivity) * sensitivity
   };
 
-  if (delta.top  > 0) {
+  if (delta.top > 0) {
     return 'down';
   }
 
-  if (delta.top  < 0) {
+  if (delta.top < 0) {
     return 'up';
   }
 
@@ -32,5 +33,4 @@ export default function checkScrollDirection(lastPosition = null, newPosition = 
   if (delta.left < 0) {
     return 'left';
   }
-
 }

--- a/app/initializers/viewport-config.js
+++ b/app/initializers/viewport-config.js
@@ -2,23 +2,27 @@ import Ember from 'ember';
 import config from '../config/environment';
 
 const defaultConfig = {
-  viewportSpy               : false,
-  viewportScrollSensitivity : 1,
-  viewportRefreshRate       : 100,
-  viewportListeners         : [],
+  viewportSpy: false,
+  viewportScrollSensitivity: 1,
+  viewportRefreshRate: 100,
+  viewportListeners: [
+    { context: window, event: 'scroll.scrollable' },
+    { context: window, event: 'resize.resizable' },
+    { context: document, event: 'touchmove.scrollable' }
+  ],
   viewportTolerance: {
-    top    : 0,
-    left   : 0,
-    bottom : 0,
-    right  : 0
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0
   }
 };
 
 const { merge } = Ember;
 
-export function initialize(_container, application) {
+export function initialize() {
+  const application = arguments[1] || arguments[0];
   const { viewportConfig = {} } = config;
-
   const mergedConfig = merge(defaultConfig, viewportConfig);
 
   application.register('config:in-viewport', mergedConfig, { instantiate: false });


### PR DESCRIPTION
This commit fixes a deprecation warning in Ember 2.x where initializers
no longer receive the container as an argument. The fix is backwards
compatible.

It also fixes an issue where default listeners would not be applied
correctly.