### PR TITLE
Prevent unsetting viewportEntered when not spying

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -134,7 +134,9 @@ export default Mixin.create({
       triggeredEventName = 'didExitViewport';
     }
 
-    set(this, 'viewportEntered', hasEnteredViewport);
+    if (get(this, 'viewportSpy') || !viewportEntered) {
+      set(this, 'viewportEntered', hasEnteredViewport);
+    }
 
     this.trigger(triggeredEventName);
   },


### PR DESCRIPTION
When scrolling through a large list of components with the InViewport mixin, the `_triggerDidAccessViewport` method can set the `viewportEntered` property to false after listeners for the component have been unbound, causing the components to remain stuck in their outside viewport state. `viewportEntered` should only be set back to false if the spy is being used.