### PR TITLE
use this.get pattern to avoid forEach = _ember["default"].EnumerableUtils.forEach.

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -45,7 +45,7 @@ export default Mixin.create({
     this._bindScrollDirectionListener(window, get(this, 'viewportScrollSensitivity'));
 
     if (!get(this, 'viewportUseRAF')) {
-      get(this, 'viewportListeners').forEach((listener) => {
+      _.forEach(get(this, 'viewportListeners'), (listener) => {
         const { context, event } = listener;
         this._bindListeners(context, event);
       });
@@ -204,7 +204,7 @@ export default Mixin.create({
       });
     }
 
-    get(this, 'viewportListeners').forEach((listener) => {
+    _.forEach(get(this, 'viewportListeners'), (listener) => {
       const { context, event } = listener;
       $(context).off(`${event}.${elementId}`);
     });

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -45,7 +45,7 @@ export default Mixin.create({
     this._bindScrollDirectionListener(window, get(this, 'viewportScrollSensitivity'));
 
     if (!get(this, 'viewportUseRAF')) {
-      _.forEach(get(this, 'viewportListeners'), (listener) => {
+      this.get('viewportListeners').forEach((listener) => {
         const { context, event } = listener;
         this._bindListeners(context, event);
       });
@@ -204,7 +204,7 @@ export default Mixin.create({
       });
     }
 
-    _.forEach(get(this, 'viewportListeners'), (listener) => {
+    this.get('viewportListeners').forEach((listener) => {
       const { context, event } = listener;
       $(context).off(`${event}.${elementId}`);
     });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "https://github.com/dockyard/ember-in-viewport",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dockyard/ember-in-viewport"  
+  },
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
use this.get, instead of get(this...), so don't need to have lodash involved.