### PR TITLE
Use innerHeight and innerWidth to get correct values on mobile safari

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -78,14 +78,13 @@ export default Mixin.create({
       return;
     }
 
-    const $contextEl = $(context);
     const boundingClientRect = element.getBoundingClientRect();
 
     this._triggerDidAccessViewport(
       isInViewport(
         boundingClientRect,
-        $contextEl.height(),
-        $contextEl.width(),
+        context.innerHeight,
+        context.innerWidth,
         get(this, 'viewportTolerance')
       )
     );

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -78,13 +78,14 @@ export default Mixin.create({
       return;
     }
 
+    const $contextEl = $(context);
     const boundingClientRect = element.getBoundingClientRect();
 
     this._triggerDidAccessViewport(
       isInViewport(
         boundingClientRect,
-        context.innerHeight,
-        context.innerWidth,
+        $context.innerHeight(),
+        $context.innerWidth(),
         get(this, 'viewportTolerance')
       )
     );


### PR DESCRIPTION
## Fix mobile Safari minimal-ui issue
When scrolled down mobile Safari goes into minimal-ui mode and jQuery's `.height()` function does not account for that, whereas innerHeight is getting correct value.

## Problem
This PR is meant to fix an issue on mobile Safari, when bottom is calculated incorrectly, resulting in `didEnterViewport` firing late.