### PR TITLE
Using the injected container is deprecated in Ember 2.3. 

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -10,6 +10,7 @@ const {
   merge,
   typeOf,
   assert,
+  getOwner,	
   $,
   get,
   set,
@@ -58,8 +59,8 @@ export default Mixin.create({
   },
 
   _buildOptions(defaultOptions = {}) {
-    if (this.container) {
-      return merge(defaultOptions, this.container.lookup('config:in-viewport'));
+    if (getOwner(this)) {
+      return merge(defaultOptions, getOwner(this).lookup('config:in-viewport'));
     }
   },
 

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -10,7 +10,7 @@ const {
   merge,
   typeOf,
   assert,
-  getOwner,	
+  getOwner,
   $,
   get,
   set,

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-in-viewport",
   "dependencies": {
-    "ember": "1.13.7",
+    "ember": "~2.3.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",


### PR DESCRIPTION
Using the injected `container` is deprecated in Ember 2.3. Changed mixin to use the `getOwner` helper instead
http://emberjs.com/deprecations/v2.x/#toc_injected-container-access