### PR TITLE
allow disabled viewport listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![Download count all time](https://img.shields.io/npm/dt/ember-in-viewport.svg) [![npm version](https://badge.fury.io/js/ember-in-viewport.svg)](http://badge.fury.io/js/ember-in-viewport) [![Build Status](https://travis-ci.org/DockYard/ember-in-viewport.svg)](https://travis-ci.org/dockyard/ember-in-viewport) [![Ember Observer Score](http://emberobserver.com/badges/ember-in-viewport.svg)](http://emberobserver.com/addons/ember-in-viewport)
 
-This `ember-cli` addon adds a simple, highly performant Ember Mixin to your app. This Mixin, when added to a `View` or `Component` (collectively referred to as `Components`), will allow you to check if that `Component` has entered the browser's viewport. By default, the Mixin uses the `requestAnimationFrame` API if it detects it in your user's browser – failing which, it fallsback to using the Ember run loop and event listeners. 
+This `ember-cli` addon adds a simple, highly performant Ember Mixin to your app. This Mixin, when added to a `View` or `Component` (collectively referred to as `Components`), will allow you to check if that `Component` has entered the browser's viewport. By default, the Mixin uses the `requestAnimationFrame` API if it detects it in your user's browser – failing which, it fallsback to using the Ember run loop and event listeners.
 
 ## Demo
 - App: http://development.ember-in-viewport-demo.divshot.io/
@@ -41,7 +41,7 @@ export default Ember.Component.extend(InViewportMixin, {
 ```
 
 ##### `didScroll(up,down,left,right)`
-The `didScroll` hook fires when an element enters the viewport. For example, if you scrolled down in order to move the element in the viewport, the `didScroll` hook would fire and also receieve the direction as a string. You can then handle it like another hook as in the above example. 
+The `didScroll` hook fires when an element enters the viewport. For example, if you scrolled down in order to move the element in the viewport, the `didScroll` hook would fire and also receieve the direction as a string. You can then handle it like another hook as in the above example.
 
 ```js
 export default Ember.Component.extend(InViewportMixin, {
@@ -70,6 +70,7 @@ The mixin comes with some options. Due to the way listeners and `requestAnimatio
 export default Ember.Component.extend(InViewportMixin, {
   viewportOptionsOverride: Ember.on('didInsertElement', function() {
     Ember.setProperties(this, {
+      viewportEnabled           : true,
       viewportUseRAF            : true,
       viewportSpy               : false,
       viewportScrollSensitivity : 1,
@@ -85,6 +86,12 @@ export default Ember.Component.extend(InViewportMixin, {
 });
 ```
 
+- `viewportEnabled: boolean`
+
+  Default: `true`
+
+  Set to false to have no listeners registered. Useful if you have components that function with either viewport listening on or off.
+
 - `viewportUseRAF: boolean`
 
   Default: Depends on browser
@@ -95,13 +102,13 @@ export default Ember.Component.extend(InViewportMixin, {
 
   Default: `false`
 
-  When `true`, the Mixin will continually watch the `Component` and re-fire hooks whenever it enters or leaves the viewport. Because this is expensive, this behaviour is opt-in. When false, the Mixin will only watch the `Component` until it enters the viewport once, and then it sets `viewportEntered` to `true` (permanently), and unbinds listeners. This reduces the load on the Ember run loop and your application. 
+  When `true`, the Mixin will continually watch the `Component` and re-fire hooks whenever it enters or leaves the viewport. Because this is expensive, this behaviour is opt-in. When false, the Mixin will only watch the `Component` until it enters the viewport once, and then it sets `viewportEntered` to `true` (permanently), and unbinds listeners. This reduces the load on the Ember run loop and your application.
 
 - `viewportScrollSensitivity: number`
 
   Default: `1`
 
-  This value determines the degree of sensitivity (in `px`) in which a DOM element is considered to have scrolled into the viewport. For example, if you set `viewportScrollSensitivity` to `10`, the `didScroll{...}` hooks would only fire if the scroll was greater than `10px`. 
+  This value determines the degree of sensitivity (in `px`) in which a DOM element is considered to have scrolled into the viewport. For example, if you set `viewportScrollSensitivity` to `10`, the `didScroll{...}` hooks would only fire if the scroll was greater than `10px`.
 
 - `viewportRefreshRate: number`
 
@@ -109,13 +116,13 @@ export default Ember.Component.extend(InViewportMixin, {
 
   If `requestAnimationFrame` is not present, this value determines how often the Mixin checks your component to determine whether or not it has entered or left the viewport. The lower this number, the more often it checks, and the more load is placed on your application. Generally, you'll want this value between `100` to `300`, which is about the range at which people consider things to be "real-time".
 
-  This value also affects how often the Mixin checks scroll direction. 
+  This value also affects how often the Mixin checks scroll direction.
 
 - `viewportTolerance: object`
 
   Default: `{ top: 0, left: 0, bottom: 0, right: 0 }`
 
-  This option determines how accurately the `Component` needs to be within the viewport for it to be considered as entered. 
+  This option determines how accurately the `Component` needs to be within the viewport for it to be considered as entered.
 
 ### Global options
 
@@ -126,8 +133,9 @@ module.exports = function(environment) {
   var ENV = {
     // ...
     viewportConfig: {
-      viewportSpy               : false,
+      viewportEnabled           : false,
       viewportUseRAF            : true,
+      viewportSpy               : false,
       viewportScrollSensitivity : 1,
       viewportRefreshRate       : 100,
       viewportListeners         : [],

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -44,15 +44,9 @@ export default Mixin.create({
       return;
     }
 
-    this._setInitialViewport(window);
-    this._addObserverIfNotSpying();
-    this._bindScrollDirectionListener(window, get(this, 'viewportScrollSensitivity'));
-
-    if (!get(this, 'viewportUseRAF')) {
-      get(this, 'viewportListeners').forEach((listener) => {
-        const { context, event } = listener;
-        this._bindListeners(context, event);
-      });
+    const viewportEnabled = get(this, 'viewportEnabled');
+    if (viewportEnabled) {
+      this._startListening();
     }
   },
 
@@ -66,6 +60,19 @@ export default Mixin.create({
 
     if (owner) {
       return assign(defaultOptions, owner.lookup('config:in-viewport'));
+    }
+  },
+
+  _startListening() {
+    this._setInitialViewport(window);
+    this._addObserverIfNotSpying();
+    this._bindScrollDirectionListener(window, get(this, 'viewportScrollSensitivity'));
+
+    if (!get(this, 'viewportUseRAF')) {
+      get(this, 'viewportListeners').forEach((listener) => {
+        const { context, event } = listener;
+        this._bindListeners(context, event);
+      });
     }
   },
 

--- a/app/initializers/viewport-config.js
+++ b/app/initializers/viewport-config.js
@@ -3,6 +3,7 @@ import config from '../config/environment';
 import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
 
 const defaultConfig = {
+  viewportEnabled: true,
   viewportSpy: false,
   viewportScrollSensitivity: 1,
   viewportRefreshRate: 100,

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -9,7 +9,7 @@ test('Component is active when in viewport', function(assert) {
   visit('/');
 
   andThen(() => {
-    assert.ok(find('.my-component.top.active').length);
+    assert.ok(find('.my-component.top.start-enabled.active').length);
   });
 });
 
@@ -48,9 +48,19 @@ test('Component moves back to inactive when scrolled out of viewport', function(
     find(window).scrollTop(2000);
   });
 
-  waitFor('.my-component.top.inactive');
+  waitFor('.my-component.top.start-enabled.inactive');
 
   andThen(() => {
-    assert.ok(find('.my-component.top.inactive').length);
+    assert.ok(find('.my-component.top.start-enabled.inactive').length);
+  });
+});
+
+test('Component can be disabled', function(assert) {
+  assert.expect(1);
+
+  visit('/');
+
+  andThen(() => {
+    assert.ok(find('.my-component.top.start-disabled.inactive').length);
   });
 });

--- a/tests/dummy/app/components/my-component.js
+++ b/tests/dummy/app/components/my-component.js
@@ -15,13 +15,18 @@ export default Component.extend(InViewportMixin, {
     let options = {};
 
     let {
-      viewportSpyOverride
+      viewportSpyOverride,
+      viewportEnabledOverride
     } = getProperties(this,
-      'viewportSpyOverride'
+      'viewportSpyOverride',
+      'viewportEnabledOverride'
     );
 
     if (viewportSpyOverride !== undefined) {
       options.viewportSpy = viewportSpyOverride;
+    }
+    if (viewportEnabledOverride !== undefined) {
+      options.viewportEnabled = viewportEnabledOverride;
     }
 
     setProperties(this, options);

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,8 +1,15 @@
 <div>
-  {{#my-component class="top"
+  {{#my-component class="top start-enabled"
     viewportSpyOverride=true
   }}
-    <p>Hi!</p>
+    <p>Starts enabled</p>
+  {{/my-component}}
+
+  {{#my-component class="top start-disabled"
+    viewportSpyOverride=true
+    viewportEnabledOverride=false
+  }}
+    <p>Starts disabled</p>
   {{/my-component}}
 </div>
 


### PR DESCRIPTION
Implementation of #84.

- [x] decide if falsy `viewportRefreshRate` is the way to go, or use a new bool instead.
- [x] needs updated Readme.