### PR TITLE
Fix for items larger than viewport

### DIFF
--- a/addon/utils/is-in-viewport.js
+++ b/addon/utils/is-in-viewport.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 
 const assign = Ember.assign || Ember.merge;
-
 const defaultTolerance = {
   top: 0,
   left: 0,
@@ -12,9 +11,12 @@ const defaultTolerance = {
 const isAxisInViewport = function(start, startTolerance, end, endTolerance, limit) {
   // Dimensions are fully LARGER than the viewport or fully WITHIN the viewport.
   const exceedingLimit = (end + endTolerance) - (start + startTolerance) > limit;
-  return exceedingLimit 
-    ? start <= startTolerance && (end - endTolerance) >= limit
-    : (start + startTolerance) >= 0 && (end - endTolerance) <= limit;
+
+  if (exceedingLimit) {
+    return start <= startTolerance && (end - endTolerance) >= limit;
+  }
+
+  return (start + startTolerance) >= 0 && (end - endTolerance) <= limit;
 };
 
 export default function isInViewport(boundingClientRect = {}, height = 0, width = 0, tolerance = defaultTolerance) {
@@ -28,5 +30,5 @@ export default function isInViewport(boundingClientRect = {}, height = 0, width 
   } = tolerances;
 
   return isAxisInViewport(top, topTolerance, bottom, bottomTolerance, height) &&
-      isAxisInViewport(left, leftTolerance, right, rightTolerance, width);
+    isAxisInViewport(left, leftTolerance, right, rightTolerance, width);
 }

--- a/addon/utils/is-in-viewport.js
+++ b/addon/utils/is-in-viewport.js
@@ -9,6 +9,14 @@ const defaultTolerance = {
   right: 0
 };
 
+const isAxisInViewport = function(start, startTolerance, end, endTolerance, limit) {
+  // Dimensions are fully LARGER than the viewport or fully WITHIN the viewport.
+  const exceedingLimit = (end + endTolerance) - (start + startTolerance) > limit;
+  return exceedingLimit 
+    ? start <= startTolerance && (end - endTolerance) >= limit
+    : (start + startTolerance) >= 0 && (end - endTolerance) <= limit;
+};
+
 export default function isInViewport(boundingClientRect = {}, height = 0, width = 0, tolerance = defaultTolerance) {
   const { top, left, bottom, right } = boundingClientRect;
   const tolerances = assign(defaultTolerance, tolerance);
@@ -19,10 +27,6 @@ export default function isInViewport(boundingClientRect = {}, height = 0, width 
     right: rightTolerance
   } = tolerances;
 
-  return (
-    (top + topTolerance)       >= 0 &&
-    (left + leftTolerance)     >= 0 &&
-    (bottom - bottomTolerance) <= height &&
-    (right - rightTolerance)   <= width
-  );
+  return isAxisInViewport(top, topTolerance, bottom, bottomTolerance, height) &&
+      isAxisInViewport(left, leftTolerance, right, rightTolerance, width);
 }


### PR DESCRIPTION
For each axis (X,Y) the item is considered in the viewport when:  
- It's dimensions are fully within the viewport (original calculation)
- It's dimension are fully outside the viewport (new)

So the behaviour only changes for items that are actually taller/wider :)

Closes #37
