### PR TITLE
bug: handle subpixel values in viewport dims

### DIFF
--- a/addon/utils/is-in-viewport.js
+++ b/addon/utils/is-in-viewport.js
@@ -22,7 +22,7 @@ export default function isInViewport(boundingClientRect = {}, height = 0, width 
   return (
     (top + topTolerance)       >= 0 &&
     (left + leftTolerance)     >= 0 &&
-    (bottom - bottomTolerance) <= height &&
-    (right - rightTolerance)   <= width
+    (Math.round(bottom) - bottomTolerance) <= Math.round(height) &&
+    (Math.round(right) - rightTolerance)   <= Math.round(width)
   );
 }

--- a/tests/unit/utils/is-in-viewport-test.js
+++ b/tests/unit/utils/is-in-viewport-test.js
@@ -55,3 +55,55 @@ test('returns true if dimensions not within viewport but within tolerance', func
   const result = isInViewport(fakeRectNotInViewport, innerHeight, innerWidth, fakeTolerance);
   assert.ok(result);
 });
+
+test('returns true if rect with subpixel height is within viewport', function(assert) {
+  const innerHeight = 400;
+  const innerWidth = 1280;
+  const fakeRectWithSubpixelsInViewport = {
+    top: 300,
+    left: 150,
+    bottom: 400.4,
+    right: 1130
+  };
+  const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
+  assert.ok(result);
+});
+
+test('returns true if rect with subpixel width is within viewport', function(assert) {
+  const innerHeight = 400;
+  const innerWidth = 1280;
+  const fakeRectWithSubpixelsInViewport = {
+    top: 300,
+    left: 150,
+    bottom: 400,
+    right: 1280.4
+  };
+  const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
+  assert.ok(result);
+});
+
+test('returns false if rect with subpixel height is not within viewport', function(assert) {
+  const innerHeight = 400;
+  const innerWidth = 1280;
+  const fakeRectWithSubpixelsInViewport = {
+    top: 300,
+    left: 150,
+    bottom: 400.8,
+    right: 1130
+  };
+  const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
+  assert.notOk(result);
+});
+
+test('returns false if rect with subpixel width is not within viewport', function(assert) {
+  const innerHeight = 400;
+  const innerWidth = 1280;
+  const fakeRectWithSubpixelsInViewport = {
+    top: 300,
+    left: 150,
+    bottom: 400,
+    right: 1280.7
+  };
+  const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
+  assert.notOk(result);
+});


### PR DESCRIPTION
Rounds the dimensions on the DOMRect of the in-viewport element since
`jQuery.innerWidth()` (or `height`) return integers.
`Element.getBoundingClientRect()` can return subpixels (as floating
point numbers) that if not handled will result in elements not being
considered in the viewport by the `is-in-viewport` helper (even though
they are).

This is particularly important when the user has zoomed the window,
in which case the browser may scale the size of the viewport, resulting
in the dimensions having fractional parts, e.g., the width might be
`1451.1112060546875`.

Closes #96

# Details

Rounds the `right` and `bottom` properties on the `DOMRect` returned from `Element.getBoundingClientRect()` on the element being checked to integers.


# Functional Testing

I have tested by `npm link`ing this change against [this repo](https://les2.github.io/ember-light-table-zoom-bug/#/elt-demo) and verifying that the viewport detection works correctly.

I have personally tested in recent versions the following browsers on OS X El Capitan using the above method:
- Firefox
- Safari
- Chrome