### PR TITLE
Adds installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ This `ember-cli` addon adds a simple, highly performant Ember Mixin to your app.
 - App: http://development.ember-in-viewport-demo.divshot.io/
 - Source: https://github.com/poteto/ember-in-viewport-demo
 
+# Installation
+
+```
+ember install ember-in-viewport
+```
+
 ## Usage
 Usage is simple. First, add the Mixin to your `Component`:
 


### PR DESCRIPTION
While reading through the README, I noticed there wasn't an installation section. So I'm just adding an installation header with the command used to install this on another project.

## Changes proposed in this pull request

- Adds an installation header with a code snippet to run `ember install ember-in-viewport`