### PR TITLE
[WIP] Uses a single requestAnimationFrame listener

### DIFF
--- a/addon/services/viewport.js
+++ b/addon/services/viewport.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+
+const {
+  A,
+  computed
+} = Ember;
+
+export default Ember.Service.extend({
+  _pool: computed(()=> A()),
+  init() {
+    this.flush();
+  },
+  flush() {
+    window.requestAnimationFrame(()=> {
+      if (this.get('isDestroying')) {
+        return;
+      }
+      let currentPool = this.get('_pool');
+      this.set('_pool', A());
+      currentPool.forEach((fn)=> fn());
+      this.flush();
+    });
+  },
+  add(fn) {
+    this.get('_pool').pushObject(fn);
+    return fn;
+  },
+  remove(fn) {
+    this.get('_pool').removeObject(fn);
+    return fn;
+  }
+});

--- a/app/services/viewport.js
+++ b/app/services/viewport.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-in-viewport/services/viewport';

--- a/tests/unit/services/viewport-test.js
+++ b/tests/unit/services/viewport-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:viewport', 'Unit | Service | viewport', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
Hi,
this PR is an attempt at tackling the performance issues raised in #42.

We realised that using `ember-in-viewport` so that the hundreds of images in page won't be fetched all at once works great except it is painfully heavy on memory because (AFAICT) you run with hundreds of recurring handlers on `requestAnimationFrame`.

This PR introduces a service that handles all the nodes in a single `requestAnimationFrame`.

It is not meant to be merged as is, but rather discussed to determine whether the approach is sound and whether it is worthwhile to keep investing time in tests, docs, etc...

Looking forward to your feedback!