### PR TITLE
Fix item larger than viewport

### DIFF
--- a/addon/utils/is-in-viewport.js
+++ b/addon/utils/is-in-viewport.js
@@ -9,6 +9,14 @@ const defaultTolerance = {
   right: 0
 };
 
+const isAxisInViewport = function(start, startTolerance, end, endTolerance, limit) {
+  // Dimensions are fully LARGER than the viewport or fully WITHIN the viewport.
+  const exceedingLimit = (end + endTolerance) - (start + startTolerance) > limit;
+  return exceedingLimit
+    ? start <= startTolerance && (end - endTolerance) >= limit
+    : (start + startTolerance) >= 0 && (end - endTolerance) <= limit;
+};
+
 export default function isInViewport(boundingClientRect = {}, height = 0, width = 0, tolerance = defaultTolerance) {
   const { top, left, bottom, right } = boundingClientRect;
   const tolerances = assign(assign({}, defaultTolerance), tolerance);
@@ -19,10 +27,6 @@ export default function isInViewport(boundingClientRect = {}, height = 0, width 
     right: rightTolerance
   } = tolerances;
 
-  return (
-    (top + topTolerance)       >= 0 &&
-    (left + leftTolerance)     >= 0 &&
-    (Math.round(bottom) - bottomTolerance) <= Math.round(height) &&
-    (Math.round(right) - rightTolerance)   <= Math.round(width)
-  );
+  return isAxisInViewport(top, topTolerance, (Math.round(bottom), bottomTolerance, Math.round(height)) &&
+      isAxisInViewport(left, leftTolerance, Math.round(right), rightTolerance, Math.round(width));
 }

--- a/addon/utils/is-in-viewport.js
+++ b/addon/utils/is-in-viewport.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 
 const assign = Ember.assign || Ember.merge;
-
 const defaultTolerance = {
   top: 0,
   left: 0,
@@ -12,9 +11,12 @@ const defaultTolerance = {
 const isAxisInViewport = function(start, startTolerance, end, endTolerance, limit) {
   // Dimensions are fully LARGER than the viewport or fully WITHIN the viewport.
   const exceedingLimit = (end + endTolerance) - (start + startTolerance) > limit;
-  return exceedingLimit
-    ? start <= startTolerance && (end - endTolerance) >= limit
-    : (start + startTolerance) >= 0 && (end - endTolerance) <= limit;
+
+  if (exceedingLimit) {
+    return start <= startTolerance && (end - endTolerance) >= limit;
+  }
+
+  return (start + startTolerance) >= 0 && (end - endTolerance) <= limit;
 };
 
 export default function isInViewport(boundingClientRect = {}, height = 0, width = 0, tolerance = defaultTolerance) {
@@ -27,6 +29,6 @@ export default function isInViewport(boundingClientRect = {}, height = 0, width 
     right: rightTolerance
   } = tolerances;
 
-  return isAxisInViewport(top, topTolerance, (Math.round(bottom), bottomTolerance, Math.round(height)) &&
-      isAxisInViewport(left, leftTolerance, Math.round(right), rightTolerance, Math.round(width));
+  return isAxisInViewport(top, topTolerance, Math.round(bottom), bottomTolerance, Math.round(height)) &&
+    isAxisInViewport(left, leftTolerance, Math.round(right), rightTolerance, Math.round(width));
 }


### PR DESCRIPTION
This is a rebased version of https://github.com/DockYard/ember-in-viewport/pull/88

For each axis (X,Y) the item is considered in the viewport when:

It's dimensions are fully within the viewport (original calculation)
It's dimension are fully outside the viewport (new)
So the behaviour only changes for items that are actually taller/wider :)

Closes #37