### PR TITLE
fixes test/build

### DIFF
--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -29,7 +29,7 @@ test('Component moves to active when scrolled into viewport', function(assert) {
   visit('/');
 
   andThen(() => {
-    find(window).scrollTop(2000);
+    find('.my-component.bottom').get(0).scrollIntoView();
   });
 
   waitFor('.my-component.bottom.active');


### PR DESCRIPTION
scrolling the window did not actually bring the element into the viewport.
the test container needed to be scrolled

## Changes proposed in this pull request

This PR fixes the build by fixing a test that is currently failing.