### PR TITLE
Use IntersectionObserver to detect in viewport

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -1,15 +1,15 @@
 import Ember from 'ember';
 import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
-import canUseRAF from 'ember-in-viewport/utils/can-use-raf';
-import isInViewport from 'ember-in-viewport/utils/is-in-viewport';
-import checkScrollDirection from 'ember-in-viewport/utils/check-scroll-direction';
+// import canUseRAF from 'ember-in-viewport/utils/can-use-raf';
+// import isInViewport from 'ember-in-viewport/utils/is-in-viewport';
+// import checkScrollDirection from 'ember-in-viewport/utils/check-scroll-direction';
 
 const {
   Mixin,
   setProperties,
-  typeOf,
+  // typeOf,
   assert,
-  $,
+  // $,
   get,
   set,
   run: { scheduleOnce, debounce, bind, next },
@@ -19,17 +19,18 @@ const {
 
 const assign = Ember.assign || Ember.merge;
 
-const rAFIDS = {};
-const lastDirection = {};
-const lastPosition = {};
+// const rAFIDS = {};
+// const lastDirection = {};
+// const lastPosition = {};
 
 export default Mixin.create({
+  observer: null,
   viewportExited: not('viewportEntered').readOnly(),
 
   init() {
     this._super(...arguments);
     const options = assign({
-      viewportUseRAF: canUseRAF(),
+      // viewportUseRAF: canUseRAF(),
       viewportEntered: false,
       viewportListeners: []
     }, this._buildOptions());
@@ -64,164 +65,164 @@ export default Mixin.create({
   },
 
   _startListening() {
-    this._setInitialViewport(window);
-    this._addObserverIfNotSpying();
-    this._bindScrollDirectionListener(window, get(this, 'viewportScrollSensitivity'));
+    this._setInitialViewport();
+    // this._addObserverIfNotSpying();
+    // this._bindScrollDirectionListener(window, get(this, 'viewportScrollSensitivity'));
 
-    if (!get(this, 'viewportUseRAF')) {
-      get(this, 'viewportListeners').forEach((listener) => {
-        const { context, event } = listener;
-        this._bindListeners(context, event);
-      });
-    }
+    // if (!get(this, 'viewportUseRAF')) {
+    //   get(this, 'viewportListeners').forEach((listener) => {
+    //     const { context, event } = listener;
+    //     this._bindListeners(context, event);
+    //   });
+    // }
   },
 
-  _addObserverIfNotSpying() {
-    if (!get(this, 'viewportSpy')) {
-      this.addObserver('viewportEntered', this, this._unbindIfEntered);
-    }
-  },
+  // _addObserverIfNotSpying() {
+  //   if (!get(this, 'viewportSpy')) {
+  //     this.addObserver('viewportEntered', this, this._unbindIfEntered);
+  //   }
+  // },
 
-  _setViewportEntered(context = null) {
-    assert('You must pass a valid context to _setViewportEntered', context);
+  _setViewportEntered(/* context = null */) {
+    // assert('You must pass a valid context to _setViewportEntered', context);
 
-    const element = get(this, 'element');
-
-    if (!element) {
+    if (!this.element) {
       return;
     }
 
-    const $contextEl = $(context);
-    const boundingClientRect = element.getBoundingClientRect();
-
-    this._triggerDidAccessViewport(
-      isInViewport(
-        boundingClientRect,
-        $contextEl.innerHeight(),
-        $contextEl.innerWidth(),
-        get(this, 'viewportTolerance')
-      )
-    );
-
-    if (boundingClientRect && get(this, 'viewportUseRAF')) {
-      rAFIDS[get(this, 'elementId')] = window.requestAnimationFrame(
-        bind(this, this._setViewportEntered, context)
-      );
-    }
-  },
-
-  _triggerDidScrollDirection($contextEl = null, sensitivity = 1) {
-    assert('You must pass a valid context element to _triggerDidScrollDirection', $contextEl);
-    assert('sensitivity cannot be 0', sensitivity);
-
-    const elementId = get(this, 'elementId');
-    const lastDirectionForEl = lastDirection[elementId];
-    const lastPositionForEl = lastPosition[elementId];
-    const newPosition = {
-      top: $contextEl.scrollTop(),
-      left: $contextEl.scrollLeft()
-    };
-
-    const scrollDirection = checkScrollDirection(lastPositionForEl, newPosition, sensitivity);
-    const directionChanged = scrollDirection !== lastDirectionForEl;
-
-    if (scrollDirection && directionChanged && get(this, 'viewportEntered')) {
-      this.trigger('didScroll', scrollDirection);
-      lastDirection[elementId] = scrollDirection;
+    const { top, left, bottom, right } = this.viewportTolerance;
+    const options = {
+      root: null, 
+      rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
+      threshold: this.viewportScrollSensitivity
     }
 
-    lastPosition[elementId] = newPosition;
+    this.observer = new IntersectionObserver(bind(this, this._onIntersection), options)
+    this.observer.observe(this.element);
   },
 
-  _triggerDidAccessViewport(hasEnteredViewport = false) {
-    const viewportEntered = get(this, 'viewportEntered');
-    const didEnter = !viewportEntered && hasEnteredViewport;
-    const didLeave = viewportEntered && !hasEnteredViewport;
+  _onIntersection(entries) {
+    let entry = entries[0];
+
+    if (entry.isIntersecting) {
+      set(this, 'viewportEntered', true);
+    } else if (entry.intersectionRatio <= 0) { // exiting viewport
+      set(this, 'viewportEntered', false);
+    }
+
+    this._triggerDidAccessViewport();
+  },
+
+  // _triggerDidScrollDirection($contextEl = null, sensitivity = 1) {
+  //   assert('You must pass a valid context element to _triggerDidScrollDirection', $contextEl);
+  //   assert('sensitivity cannot be 0', sensitivity);
+
+  //   const elementId = get(this, 'elementId');
+  //   const lastDirectionForEl = lastDirection[elementId];
+  //   const lastPositionForEl = lastPosition[elementId];
+  //   const newPosition = {
+  //     top: $contextEl.scrollTop(),
+  //     left: $contextEl.scrollLeft()
+  //   };
+
+  //   const scrollDirection = checkScrollDirection(lastPositionForEl, newPosition, sensitivity);
+  //   const directionChanged = scrollDirection !== lastDirectionForEl;
+
+  //   if (scrollDirection && directionChanged && get(this, 'viewportEntered')) {
+  //     this.trigger('didScroll', scrollDirection);
+  //     lastDirection[elementId] = scrollDirection;
+  //   }
+
+  //   lastPosition[elementId] = newPosition;
+  // },
+
+  _triggerDidAccessViewport(/* hasEnteredViewport = false */) {
+    // const didEnter = !viewportEntered && hasEnteredViewport;
+    // const didLeave = viewportEntered && !hasEnteredViewport;
     let triggeredEventName = '';
 
-    if (didEnter) {
+    const viewportEntered = get(this, 'viewportEntered');
+    if (viewportEntered) {
       triggeredEventName = 'didEnterViewport';
-    }
-
-    if (didLeave) {
+    } else {
       triggeredEventName = 'didExitViewport';
     }
 
-    if (get(this, 'viewportSpy') || !viewportEntered) {
-      set(this, 'viewportEntered', hasEnteredViewport);
-    }
+    // if (get(this, 'viewportSpy') || !viewportEntered) {
+    // }
 
     this.trigger(triggeredEventName);
   },
 
-  _unbindIfEntered() {
-    if (!get(this, 'viewportSpy') && get(this, 'viewportEntered')) {
-      this._unbindListeners();
-      this.removeObserver('viewportEntered', this, this._unbindIfEntered);
-      set(this, 'viewportEntered', true);
-    }
-  },
+  // _unbindIfEntered() {
+  //   if (!get(this, 'viewportSpy') && get(this, 'viewportEntered')) {
+  //     this._unbindListeners();
+  //     this.removeObserver('viewportEntered', this, this._unbindIfEntered);
+  //     set(this, 'viewportEntered', true);
+  //   }
+  // },
 
-  _setInitialViewport(context = null) {
-    assert('You must pass a valid context to _setInitialViewport', context);
+  _setInitialViewport(/* context = null */) {
+    // assert('You must pass a valid context to _setInitialViewport', context);
 
     return scheduleOnce('afterRender', this, () => {
-      this._setViewportEntered(context);
+      this._setViewportEntered();
     });
   },
 
-  _debouncedEventHandler(methodName, ...args) {
-    assert('You must pass a methodName to _debouncedEventHandler', methodName);
-    assert('methodName must be a string', typeOf(methodName) === 'string');
+  // _debouncedEventHandler(methodName, ...args) {
+  //   assert('You must pass a methodName to _debouncedEventHandler', methodName);
+  //   assert('methodName must be a string', typeOf(methodName) === 'string');
 
-    debounce(this, () => this[methodName](...args), get(this, 'viewportRefreshRate'));
-  },
+  //   debounce(this, () => this[methodName](...args), get(this, 'viewportRefreshRate'));
+  // },
 
-  _bindScrollDirectionListener(context = null, sensitivity = 1) {
-    assert('You must pass a valid context to _bindScrollDirectionListener', context);
-    assert('sensitivity cannot be 0', sensitivity);
+  // _bindScrollDirectionListener(context = null, sensitivity = 1) {
+  //   assert('You must pass a valid context to _bindScrollDirectionListener', context);
+  //   assert('sensitivity cannot be 0', sensitivity);
 
-    const $contextEl = $(context);
+  //   const $contextEl = $(context);
 
-    $contextEl.on(`scroll.directional#${get(this, 'elementId')}`, () => {
-      this._debouncedEventHandler('_triggerDidScrollDirection', $contextEl, sensitivity);
-    });
-  },
+  //   $contextEl.on(`scroll.directional#${get(this, 'elementId')}`, () => {
+  //     this._debouncedEventHandler('_triggerDidScrollDirection', $contextEl, sensitivity);
+  //   });
+  // },
 
-  _unbindScrollDirectionListener(context = null) {
-    assert('You must pass a valid context to _bindScrollDirectionListener', context);
+  // _unbindScrollDirectionListener(context = null) {
+  //   assert('You must pass a valid context to _bindScrollDirectionListener', context);
 
-    const elementId = get(this, 'elementId');
+  //   const elementId = get(this, 'elementId');
 
-    $(context).off(`scroll.directional#${elementId}`);
-    delete lastPosition[elementId];
-    delete lastDirection[elementId];
-  },
+  //   $(context).off(`scroll.directional#${elementId}`);
+  //   delete lastPosition[elementId];
+  //   delete lastDirection[elementId];
+  // },
 
-  _bindListeners(context = null, event = null) {
-    assert('You must pass a valid context to _bindListeners', context);
-    assert('You must pass a valid event to _bindListeners', event);
+  // _bindListeners(context = null, event = null) {
+  //   assert('You must pass a valid context to _bindListeners', context);
+  //   assert('You must pass a valid event to _bindListeners', event);
 
-    $(context).on(`${event}.${get(this, 'elementId')}`, () => {
-      this._debouncedEventHandler('_setViewportEntered', context);
-    });
-  },
+  //   $(context).on(`${event}.${get(this, 'elementId')}`, () => {
+  //     this._debouncedEventHandler('_setViewportEntered', context);
+  //   });
+  // },
 
   _unbindListeners() {
-    const elementId = get(this, 'elementId');
-
-    if (get(this, 'viewportUseRAF')) {
-      next(this, () => {
-        window.cancelAnimationFrame(rAFIDS[elementId]);
-        delete rAFIDS[elementId];
-      });
-    }
-
-    get(this, 'viewportListeners').forEach((listener) => {
-      const { context, event } = listener;
-      $(context).off(`${event}.${elementId}`);
+    next(this, () => {
+      this.observer.unobserve(this.element);
     });
+    // if (get(this, 'viewportUseRAF')) {
+    //   next(this, () => {
+    //     window.cancelAnimationFrame(rAFIDS[elementId]);
+    //     delete rAFIDS[elementId];
+    //   });
+    // }
 
-    this._unbindScrollDirectionListener(window);
+    // get(this, 'viewportListeners').forEach((listener) => {
+    //   const { context, event } = listener;
+    //   $(context).off(`${event}.${elementId}`);
+    // });
+
+    // this._unbindScrollDirectionListener(window);
   }
 });

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -94,7 +94,7 @@ export default Mixin.create({
     const options = {
       root: null, 
       rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
-      threshold: this.viewportScrollSensitivity
+      threshold: this.intersectionThreshold
     };
 
     this.observer = new IntersectionObserver(bind(this, this._onIntersection), options);

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -2,14 +2,14 @@ import Ember from 'ember';
 import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
 // import canUseRAF from 'ember-in-viewport/utils/can-use-raf';
 // import isInViewport from 'ember-in-viewport/utils/is-in-viewport';
-// import checkScrollDirection from 'ember-in-viewport/utils/check-scroll-direction';
+import checkScrollDirection from 'ember-in-viewport/utils/check-scroll-direction';
 
 const {
   Mixin,
   setProperties,
-  // typeOf,
+  typeOf,
   assert,
-  // $,
+  $,
   get,
   set,
   run: { scheduleOnce, debounce, bind, next },
@@ -20,8 +20,8 @@ const {
 const assign = Ember.assign || Ember.merge;
 
 // const rAFIDS = {};
-// const lastDirection = {};
-// const lastPosition = {};
+const lastDirection = {};
+const lastPosition = {};
 
 export default Mixin.create({
   observer: null,
@@ -67,7 +67,7 @@ export default Mixin.create({
   _startListening() {
     this._setInitialViewport();
     // this._addObserverIfNotSpying();
-    // this._bindScrollDirectionListener(window, get(this, 'viewportScrollSensitivity'));
+    this._bindScrollDirectionListener(window, get(this, 'viewportScrollSensitivity'));
 
     // if (!get(this, 'viewportUseRAF')) {
     //   get(this, 'viewportListeners').forEach((listener) => {
@@ -95,9 +95,9 @@ export default Mixin.create({
       root: null, 
       rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
       threshold: this.viewportScrollSensitivity
-    }
+    };
 
-    this.observer = new IntersectionObserver(bind(this, this._onIntersection), options)
+    this.observer = new IntersectionObserver(bind(this, this._onIntersection), options);
     this.observer.observe(this.element);
   },
 
@@ -113,28 +113,28 @@ export default Mixin.create({
     this._triggerDidAccessViewport();
   },
 
-  // _triggerDidScrollDirection($contextEl = null, sensitivity = 1) {
-  //   assert('You must pass a valid context element to _triggerDidScrollDirection', $contextEl);
-  //   assert('sensitivity cannot be 0', sensitivity);
+  _triggerDidScrollDirection($contextEl = null, sensitivity = 1) {
+    assert('You must pass a valid context element to _triggerDidScrollDirection', $contextEl);
+    assert('sensitivity cannot be 0', sensitivity);
 
-  //   const elementId = get(this, 'elementId');
-  //   const lastDirectionForEl = lastDirection[elementId];
-  //   const lastPositionForEl = lastPosition[elementId];
-  //   const newPosition = {
-  //     top: $contextEl.scrollTop(),
-  //     left: $contextEl.scrollLeft()
-  //   };
+    const elementId = get(this, 'elementId');
+    const lastDirectionForEl = lastDirection[elementId];
+    const lastPositionForEl = lastPosition[elementId];
+    const newPosition = {
+      top: $contextEl.scrollTop(),
+      left: $contextEl.scrollLeft()
+    };
 
-  //   const scrollDirection = checkScrollDirection(lastPositionForEl, newPosition, sensitivity);
-  //   const directionChanged = scrollDirection !== lastDirectionForEl;
+    const scrollDirection = checkScrollDirection(lastPositionForEl, newPosition, sensitivity);
+    const directionChanged = scrollDirection !== lastDirectionForEl;
 
-  //   if (scrollDirection && directionChanged && get(this, 'viewportEntered')) {
-  //     this.trigger('didScroll', scrollDirection);
-  //     lastDirection[elementId] = scrollDirection;
-  //   }
+    if (scrollDirection && directionChanged && get(this, 'viewportEntered')) {
+      this.trigger('didScroll', scrollDirection);
+      lastDirection[elementId] = scrollDirection;
+    }
 
-  //   lastPosition[elementId] = newPosition;
-  // },
+    lastPosition[elementId] = newPosition;
+  },
 
   _triggerDidAccessViewport(/* hasEnteredViewport = false */) {
     // const didEnter = !viewportEntered && hasEnteredViewport;
@@ -170,33 +170,33 @@ export default Mixin.create({
     });
   },
 
-  // _debouncedEventHandler(methodName, ...args) {
-  //   assert('You must pass a methodName to _debouncedEventHandler', methodName);
-  //   assert('methodName must be a string', typeOf(methodName) === 'string');
+  _debouncedEventHandler(methodName, ...args) {
+    assert('You must pass a methodName to _debouncedEventHandler', methodName);
+    assert('methodName must be a string', typeOf(methodName) === 'string');
 
-  //   debounce(this, () => this[methodName](...args), get(this, 'viewportRefreshRate'));
-  // },
+    debounce(this, () => this[methodName](...args), get(this, 'viewportRefreshRate'));
+  },
 
-  // _bindScrollDirectionListener(context = null, sensitivity = 1) {
-  //   assert('You must pass a valid context to _bindScrollDirectionListener', context);
-  //   assert('sensitivity cannot be 0', sensitivity);
+  _bindScrollDirectionListener(context = null, sensitivity = 1) {
+    assert('You must pass a valid context to _bindScrollDirectionListener', context);
+    assert('sensitivity cannot be 0', sensitivity);
 
-  //   const $contextEl = $(context);
+    const $contextEl = $(context);
 
-  //   $contextEl.on(`scroll.directional#${get(this, 'elementId')}`, () => {
-  //     this._debouncedEventHandler('_triggerDidScrollDirection', $contextEl, sensitivity);
-  //   });
-  // },
+    $contextEl.on(`scroll.directional#${get(this, 'elementId')}`, () => {
+      this._debouncedEventHandler('_triggerDidScrollDirection', $contextEl, sensitivity);
+    });
+  },
 
-  // _unbindScrollDirectionListener(context = null) {
-  //   assert('You must pass a valid context to _bindScrollDirectionListener', context);
+  _unbindScrollDirectionListener(context = null) {
+    assert('You must pass a valid context to _unbindScrollDirectionListener', context);
 
-  //   const elementId = get(this, 'elementId');
+    const elementId = get(this, 'elementId');
 
-  //   $(context).off(`scroll.directional#${elementId}`);
-  //   delete lastPosition[elementId];
-  //   delete lastDirection[elementId];
-  // },
+    $(context).off(`scroll.directional#${elementId}`);
+    delete lastPosition[elementId];
+    delete lastDirection[elementId];
+  },
 
   // _bindListeners(context = null, event = null) {
   //   assert('You must pass a valid context to _bindListeners', context);
@@ -223,6 +223,6 @@ export default Mixin.create({
     //   $(context).off(`${event}.${elementId}`);
     // });
 
-    // this._unbindScrollDirectionListener(window);
+    this._unbindScrollDirectionListener(window);
   }
 });

--- a/app/initializers/viewport-config.js
+++ b/app/initializers/viewport-config.js
@@ -4,7 +4,6 @@ import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
 
 const defaultConfig = {
   viewportEnabled: true,
-  viewportSpy: false,
   viewportScrollSensitivity: 1,
   viewportRefreshRate: 100,
   viewportListeners: [

--- a/app/initializers/viewport-config.js
+++ b/app/initializers/viewport-config.js
@@ -15,7 +15,8 @@ const defaultConfig = {
     left: 0,
     bottom: 0,
     right: 0
-  }
+  },
+  intersectionThreshold: 1.0,
 };
 
 if (canUseDOM) {

--- a/tests/dummy/app/components/my-component.js
+++ b/tests/dummy/app/components/my-component.js
@@ -3,6 +3,7 @@ import InViewportMixin from 'ember-in-viewport';
 
 const {
   Component,
+  get,
   on,
   getProperties, setProperties
 } = Ember;
@@ -15,20 +16,19 @@ export default Component.extend(InViewportMixin, {
     let options = {};
 
     let {
-      viewportSpyOverride,
       viewportEnabledOverride
     } = getProperties(this,
-      'viewportSpyOverride',
       'viewportEnabledOverride'
     );
 
-    if (viewportSpyOverride !== undefined) {
-      options.viewportSpy = viewportSpyOverride;
-    }
     if (viewportEnabledOverride !== undefined) {
       options.viewportEnabled = viewportEnabledOverride;
     }
 
     setProperties(this, options);
-  })
+  }),
+
+  didEnterViewport() {
+    get(this, 'infinityLoad')();
+  }
 });

--- a/tests/dummy/app/controllers/infinity.js
+++ b/tests/dummy/app/controllers/infinity.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+const { get, set } = Ember;
+
+const images = ["jarjan", "aio___", "kushsolitary", "kolage", "idiot", "gt"];
+
+const models = [...Array(10).fill().map(() => `https://s3.amazonaws.com/uifaces/faces/twitter/${images[(Math.random() * images.length) | 0]}/128.jpg`)];
+
+export default Ember.Controller.extend({
+  models,
+
+  actions: {
+    infinityLoad() {
+      const newModels = [...Array(10).fill().map(() => `https://s3.amazonaws.com/uifaces/faces/twitter/${images[(Math.random() * images.length) | 0]}/128.jpg`)];
+      get(this, 'models').push(...newModels);
+      set(this, 'models', Array.from(get(this, 'models')));
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('infinity');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/infinity.js
+++ b/tests/dummy/app/routes/infinity.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,12 +1,9 @@
 <div>
-  {{#my-component class="top start-enabled"
-    viewportSpyOverride=true
-  }}
+  {{#my-component class="top start-enabled"}}
     <p>Starts enabled</p>
   {{/my-component}}
 
   {{#my-component class="top start-disabled"
-    viewportSpyOverride=true
     viewportEnabledOverride=false
   }}
     <p>Starts disabled</p>

--- a/tests/dummy/app/templates/infinity.hbs
+++ b/tests/dummy/app/templates/infinity.hbs
@@ -1,0 +1,8 @@
+<ul>
+  {{#each models as |val|}}
+    <li><img src={{val}} /></li>
+  {{/each}}
+</ul>
+{{my-component 
+  class="infinity-component" 
+  infinityLoad=(action "infinityLoad")}}


### PR DESCRIPTION
[WIP]

## IntersectionObserver API

This is a naive implementation of the IntersectionObserver [API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).  Looks like this API is good in newer versions of Chrome/Firefox/Edge and some of the mobile browsers, but not in [WebKit](https://bugs.webkit.org/show_bug.cgi?id=159475).

I added an `/infinity` route to the dummy app to show a working implementation and hopefully build some tests around in the future.

- [ ] [ember-spaniel](https://github.com/asakusuma/ember-spaniel) - can use IntersectionObserver polyfill or `SpanielObserver` superset.
Here is an [rfc](https://github.com/linkedin/spaniel/blob/74a9f7991fd13cacecb8b680ccc7ede2ea765808/rfc/instance.md) that describes a change to the API that will use the native IntersectionObserver when available.

- [ ] Update documentation with IntersectionObserver API args - used existing `viewportTolerance`
- [ ] Update tests

Ref #106 
