### PR TITLE
Use IntersectionObserver if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![Download count all time](https://img.shields.io/npm/dt/ember-in-viewport.svg) [![npm version](https://badge.fury.io/js/ember-in-viewport.svg)](http://badge.fury.io/js/ember-in-viewport) [![Build Status](https://travis-ci.org/DockYard/ember-in-viewport.svg)](https://travis-ci.org/DockYard/ember-in-viewport) [![Ember Observer Score](http://emberobserver.com/badges/ember-in-viewport.svg)](http://emberobserver.com/addons/ember-in-viewport)
 
-This `ember-cli` addon adds a simple, highly performant Ember Mixin to your app. This Mixin, when added to a `View` or `Component` (collectively referred to as `Components`), will allow you to check if that `Component` has entered the browser's viewport. By default, the Mixin uses the `requestAnimationFrame` API if it detects it in your user's browser – failing which, it fallsback to using the Ember run loop and event listeners.
+This `ember-cli` addon adds a simple, highly performant Ember Mixin to your app. This Mixin, when added to a `View` or `Component` (collectively referred to as `Components`), will allow you to check if that `Component` has entered the browser's viewport. By default, the Mixin uses the `IntersectionObserver` API if it detects it in your user's browser – failing which, it fallsback to using `requestAnimationFrame`, then if not available, the Ember run loop and event listeners.
 
 ## Demo
 - App: http://development.ember-in-viewport-demo.divshot.io/
@@ -72,17 +72,20 @@ export default Ember.Component.extend(InViewportMixin, {
 This hook fires whenever the `Component` leaves the viewport.
 
 ### Advanced usage (options)
-The mixin comes with some options. Due to the way listeners and `requestAnimationFrame` is setup, you'll have to override the options this way:
+The mixin comes with some options. Due to the way listeners and `IntersectionObserver API` or `requestAnimationFrame` is setup, you'll have to override the options this way:
 
 ```js
 export default Ember.Component.extend(InViewportMixin, {
   viewportOptionsOverride: Ember.on('didInsertElement', function() {
     Ember.setProperties(this, {
-      viewportEnabled           : true,
-      viewportUseRAF            : true,
-      viewportSpy               : false,
-      viewportScrollSensitivity : 1,
-      viewportRefreshRate       : 150,
+      viewportEnabled                 : true,
+      viewportUseRAF                  : true,
+      viewportSpy                     : false,
+      viewportUseIntersectionObserver : true,
+      viewportScrollSensitivity       : 1,
+      viewportRefreshRate             : 150,
+      intersectionThreshold           : 1.0,
+      scrollableArea                  : null,
       viewportTolerance: {
         top    : 50,
         bottom : 50,
@@ -100,11 +103,33 @@ export default Ember.Component.extend(InViewportMixin, {
 
   Set to false to have no listeners registered. Useful if you have components that function with either viewport listening on or off.
 
+- `viewportUseIntersectionObserver: boolean`
+
+  Default: Depends on browser
+
+  The Mixin by default will use the IntersectionObserver API. If IntersectionObserver is not supported in the target browser, ember-in-viewport will fallback to rAF. 
+
+  (https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
+  (https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds#Browser_compatibility)
+
+- `intersectionThreshold: decimal`
+
+  Default: 1.0
+
+  A single number or array of numbers between 0.0 and 1.0.  A value of 0.0 means the target will be visible when the first pixel enters the viewport.  A value of 1.0 means the entire target must be visible to fire the didEnterViewport hook.
+  (https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Thresholds)
+
+- `scrollableArea`
+
+  Default: null
+
+  A CSS selector for the scrollable area.  e.g. `".my-list"`
+
 - `viewportUseRAF: boolean`
 
   Default: Depends on browser
 
-  As it's name suggests, if this is `true`, the Mixin will use `requestAnimationFrame` instead of the Ember run loop. Unless you want to force enabling or disabling this, you won't need to override this option.
+  As it's name suggests, if this is `true` and the IntersectionObserver API is not available in the target browser, the Mixin will use `requestAnimationFrame`. Unless you want to force enabling or disabling this, you won't need to override this option.
 
 - `viewportSpy: boolean`
 
@@ -122,7 +147,7 @@ export default Ember.Component.extend(InViewportMixin, {
 
   Default: `100`
 
-  If `requestAnimationFrame` is not present, this value determines how often the Mixin checks your component to determine whether or not it has entered or left the viewport. The lower this number, the more often it checks, and the more load is placed on your application. Generally, you'll want this value between `100` to `300`, which is about the range at which people consider things to be "real-time".
+  If `IntersectionObserver` and `requestAnimationFrame` is not present, this value determines how often the Mixin checks your component to determine whether or not it has entered or left the viewport. The lower this number, the more often it checks, and the more load is placed on your application. Generally, you'll want this value between `100` to `300`, which is about the range at which people consider things to be "real-time".
 
   This value also affects how often the Mixin checks scroll direction.
 
@@ -141,12 +166,15 @@ module.exports = function(environment) {
   var ENV = {
     // ...
     viewportConfig: {
-      viewportEnabled           : false,
-      viewportUseRAF            : true,
-      viewportSpy               : false,
-      viewportScrollSensitivity : 1,
-      viewportRefreshRate       : 100,
-      viewportListeners         : [],
+      viewportEnabled                 : false,
+      viewportUseRAF                  : true,
+      viewportSpy                     : false,
+      viewportUseIntersectionObserver : true,
+      viewportScrollSensitivity       : 1,
+      viewportRefreshRate             : 100,
+      viewportListeners               : [],
+      intersectionThreshold           : 1.0,
+      scrollableArea                  : null,
       viewportTolerance: {
         top    : 0,
         left   : 0,

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ export default Ember.Component.extend(InViewportMixin, {
 
   Default: Depends on browser
 
-  The Mixin by default will use the IntersectionObserver API. If IntersectionObserver is not supported in the target browser, ember-in-viewport will fallback to rAF. 
+  The Mixin by default will use the IntersectionObserver API. If IntersectionObserver is not supported in the target browser, ember-in-viewport will fallback to rAF.
 
   (https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
   (https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds#Browser_compatibility)
@@ -129,7 +129,7 @@ export default Ember.Component.extend(InViewportMixin, {
 
   Default: Depends on browser
 
-  As it's name suggests, if this is `true` and the IntersectionObserver API is not available in the target browser, the Mixin will use `requestAnimationFrame`. Unless you want to force enabling or disabling this, you won't need to override this option.
+  As its name suggests, if this is `true` and the IntersectionObserver API is not available in the target browser, the Mixin will use `requestAnimationFrame`. Unless you want to force enabling or disabling this, you won't need to override this option.
 
 - `viewportSpy: boolean`
 

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -20,7 +20,7 @@ const lastPosition = {};
 export default Mixin.create({
   /**
    * IntersectionObserverEntry
-   * 
+   *
    * @property intersectionObserver
    * @default null
    */
@@ -100,7 +100,7 @@ export default Mixin.create({
     if (get(this, 'viewportUseIntersectionObserver')) {
       const { top, left, bottom, right } = this.viewportTolerance;
       const options = {
-        root: scrollableArea, 
+        root: scrollableArea,
         rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
         threshold: get(this, 'intersectionThreshold')
       };
@@ -126,12 +126,12 @@ export default Mixin.create({
           );
         }
       }
-    } 
+    }
   },
 
   /**
    * callback provided to IntersectionObserver
-   * 
+   *
    * @method _onIntersection
    * @param {Array} - entries
    */
@@ -225,7 +225,7 @@ export default Mixin.create({
   _unbindScrollDirectionListener() {
     const elementId = get(this, 'elementId');
 
-    const context = get(this, 'scrollableArea') ? get(this, 'scrollableArea') : window;
+    const context = get(this, 'scrollableArea') || window;
 
     $(context).off(`scroll.directional#${elementId}`);
     delete lastPosition[elementId];

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -76,7 +76,7 @@ export default Mixin.create({
     if (!get(this, 'viewportUseRAF')) {
       get(this, 'viewportListeners').forEach((listener) => {
         let { context, event } = listener;
-        context = get(this, 'scrollableArea') ? get(this, 'scrollableArea') : context;
+        context = get(this, 'scrollableArea') || context;
         this._bindListeners(context, event);
       });
     }

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -1,35 +1,37 @@
-import Ember from 'ember';
+import { assign } from '@ember/polyfills';
+import Mixin from '@ember/object/mixin';
+import { typeOf } from '@ember/utils';
+import { assert } from '@ember/debug';
+import $ from 'jquery';
+import { set, get, setProperties } from '@ember/object';
+import { next, bind, debounce, scheduleOnce } from '@ember/runloop';
+import { not } from '@ember/object/computed';
+import { getOwner } from '@ember/application';
 import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
 import canUseRAF from 'ember-in-viewport/utils/can-use-raf';
+import canUseIntersectionObserver from 'ember-in-viewport/utils/can-use-intersection-observer';
 import isInViewport from 'ember-in-viewport/utils/is-in-viewport';
 import checkScrollDirection from 'ember-in-viewport/utils/check-scroll-direction';
-
-const {
-  Mixin,
-  setProperties,
-  typeOf,
-  assert,
-  $,
-  get,
-  set,
-  run: { scheduleOnce, debounce, bind, next },
-  computed: { not },
-  getOwner
-} = Ember;
-
-const assign = Ember.assign || Ember.merge;
 
 const rAFIDS = {};
 const lastDirection = {};
 const lastPosition = {};
 
 export default Mixin.create({
+  /**
+   * IntersectionObserverEntry
+   * 
+   * @property intersectionObserver
+   * @default null
+   */
+  intersectionObserver: null,
   viewportExited: not('viewportEntered').readOnly(),
 
   init() {
     this._super(...arguments);
     const options = assign({
       viewportUseRAF: canUseRAF(),
+      viewportUseIntersectionObserver: canUseIntersectionObserver(),
       viewportEntered: false,
       viewportListeners: []
     }, this._buildOptions());
@@ -53,6 +55,9 @@ export default Mixin.create({
   willDestroyElement() {
     this._super(...arguments);
     this._unbindListeners();
+    if (this.intersectionObserver) {
+      this.intersectionObserver.unobserve(this.element);
+    }
   },
 
   _buildOptions(defaultOptions = {}) {
@@ -64,13 +69,14 @@ export default Mixin.create({
   },
 
   _startListening() {
-    this._setInitialViewport(window);
+    this._setInitialViewport();
     this._addObserverIfNotSpying();
-    this._bindScrollDirectionListener(window, get(this, 'viewportScrollSensitivity'));
+    this._bindScrollDirectionListener(get(this, 'viewportScrollSensitivity'));
 
     if (!get(this, 'viewportUseRAF')) {
       get(this, 'viewportListeners').forEach((listener) => {
-        const { context, event } = listener;
+        let { context, event } = listener;
+        context = get(this, 'scrollableArea') ? get(this, 'scrollableArea') : context;
         this._bindListeners(context, event);
       });
     }
@@ -82,8 +88,8 @@ export default Mixin.create({
     }
   },
 
-  _setViewportEntered(context = null) {
-    assert('You must pass a valid context to _setViewportEntered', context);
+  _setViewportEntered() {
+    const scrollableArea = get(this, 'scrollableArea') ? document.querySelector(get(this, 'scrollableArea')) : null;
 
     const element = get(this, 'element');
 
@@ -91,22 +97,53 @@ export default Mixin.create({
       return;
     }
 
-    const $contextEl = $(context);
-    const boundingClientRect = element.getBoundingClientRect();
+    if (get(this, 'viewportUseIntersectionObserver')) {
+      const { top, left, bottom, right } = this.viewportTolerance;
+      const options = {
+        root: scrollableArea, 
+        rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
+        threshold: get(this, 'intersectionThreshold')
+      };
 
-    this._triggerDidAccessViewport(
-      isInViewport(
-        boundingClientRect,
-        $contextEl.innerHeight(),
-        $contextEl.innerWidth(),
-        get(this, 'viewportTolerance')
-      )
-    );
+      this.intersectionObserver = new IntersectionObserver(bind(this, this._onIntersection), options);
+      this.intersectionObserver.observe(element);
+    } else {
+      const $contextEl = scrollableArea ? $(scrollableArea) : $(window);
+      const boundingClientRect = element.getBoundingClientRect();
 
-    if (boundingClientRect && get(this, 'viewportUseRAF')) {
-      rAFIDS[get(this, 'elementId')] = window.requestAnimationFrame(
-        bind(this, this._setViewportEntered, context)
-      );
+      if (boundingClientRect) {
+        this._triggerDidAccessViewport(
+          isInViewport(
+            boundingClientRect,
+            $contextEl.innerHeight(),
+            $contextEl.innerWidth(),
+            get(this, 'viewportTolerance')
+          )
+        );
+        if (get(this, 'viewportUseRAF')) {
+          rAFIDS[get(this, 'elementId')] = window.requestAnimationFrame(
+            bind(this, this._setViewportEntered)
+          );
+        }
+      }
+    } 
+  },
+
+  /**
+   * callback provided to IntersectionObserver
+   * 
+   * @method _onIntersection
+   * @param {Array} - entries
+   */
+  _onIntersection(entries) {
+    const entry = entries[0];
+
+    if (entry.isIntersecting) {
+      set(this, 'viewportEntered', true);
+      this.trigger('didEnterViewport');
+    } else if (entry.intersectionRatio <= 0) { // exiting viewport
+      set(this, 'viewportEntered', false);
+      this.trigger('didExitViewport');
     }
   },
 
@@ -162,11 +199,9 @@ export default Mixin.create({
     }
   },
 
-  _setInitialViewport(context = null) {
-    assert('You must pass a valid context to _setInitialViewport', context);
-
+  _setInitialViewport() {
     return scheduleOnce('afterRender', this, () => {
-      this._setViewportEntered(context);
+      this._setViewportEntered();
     });
   },
 
@@ -177,21 +212,20 @@ export default Mixin.create({
     debounce(this, () => this[methodName](...args), get(this, 'viewportRefreshRate'));
   },
 
-  _bindScrollDirectionListener(context = null, sensitivity = 1) {
-    assert('You must pass a valid context to _bindScrollDirectionListener', context);
+  _bindScrollDirectionListener(sensitivity = 1) {
     assert('sensitivity cannot be 0', sensitivity);
 
-    const $contextEl = $(context);
+    const $contextEl = get(this, 'scrollableArea') ? $(get(this, 'scrollableArea')) : $(window);
 
     $contextEl.on(`scroll.directional#${get(this, 'elementId')}`, () => {
       this._debouncedEventHandler('_triggerDidScrollDirection', $contextEl, sensitivity);
     });
   },
 
-  _unbindScrollDirectionListener(context = null) {
-    assert('You must pass a valid context to _bindScrollDirectionListener', context);
-
+  _unbindScrollDirectionListener() {
     const elementId = get(this, 'elementId');
+
+    const context = get(this, 'scrollableArea') ? get(this, 'scrollableArea') : window;
 
     $(context).off(`scroll.directional#${elementId}`);
     delete lastPosition[elementId];
@@ -218,10 +252,11 @@ export default Mixin.create({
     }
 
     get(this, 'viewportListeners').forEach((listener) => {
-      const { context, event } = listener;
+      let { context, event } = listener;
+      context = get(this, 'scrollableArea') ? get(this, 'scrollableArea') : context;
       $(context).off(`${event}.${elementId}`);
     });
 
-    this._unbindScrollDirectionListener(window);
+    this._unbindScrollDirectionListener();
   }
 });

--- a/addon/utils/can-use-intersection-observer.js
+++ b/addon/utils/can-use-intersection-observer.js
@@ -1,0 +1,32 @@
+// Adapted from WC3's intersection polyfill
+// https://github.com/w3c/IntersectionObserver/blob/master/polyfill/intersection-observer.js
+
+import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
+
+function checkIntersectionObserver(window) {
+  if ('IntersectionObserver' in window &&
+  'IntersectionObserverEntry' in window &&
+  'intersectionRatio' in window.IntersectionObserverEntry.prototype) {
+
+    // Minimal polyfill for Edge 15's lack of `isIntersecting`
+    // See: https://github.com/w3c/IntersectionObserver/issues/211
+    if (!('isIntersecting' in window.IntersectionObserverEntry.prototype)) {
+      Object.defineProperty(window.IntersectionObserverEntry.prototype,
+        'isIntersecting', {
+        get: function () {
+          return this.intersectionRatio > 0;
+        }
+      });
+    }
+    return true;
+  }
+  return false;
+}
+
+export default function canUseIntersectionObserver() {
+  if (!canUseDOM) {
+    return false;
+  }
+
+  return checkIntersectionObserver(window);
+}

--- a/addon/utils/check-scroll-direction.js
+++ b/addon/utils/check-scroll-direction.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { assert } = Ember;
+import { assert } from '@ember/debug';
 const { floor } = Math;
 
 export default function checkScrollDirection(lastPosition = null, newPosition = {}, sensitivity = 1) {

--- a/addon/utils/is-in-viewport.js
+++ b/addon/utils/is-in-viewport.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const assign = Ember.assign || Ember.merge;
+import { assign } from '@ember/polyfills';
 
 const defaultTolerance = {
   top: 0,

--- a/app/initializers/viewport-config.js
+++ b/app/initializers/viewport-config.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { assign } from '@ember/polyfills';
 import config from '../config/environment';
 import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
 
@@ -16,7 +16,9 @@ const defaultConfig = {
     left: 0,
     bottom: 0,
     right: 0
-  }
+  },
+  intersectionThreshold: 1.0,
+  scrollableArea: null // defaults to layout view (document.documentElement)
 };
 
 if (canUseDOM) {
@@ -25,8 +27,6 @@ if (canUseDOM) {
     event: 'touchmove.scrollable'
   });
 }
-
-const assign = Ember.assign || Ember.merge;
 
 export function initialize() {
   const application = arguments[1] || arguments[0];

--- a/package-lock.json
+++ b/package-lock.json
@@ -2135,6 +2135,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3594,12 +3595,61 @@
         "ember-cli-babel": "6.10.0"
       }
     },
+    "ember-factory-for-polyfill": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
+      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
+      "requires": {
+        "ember-cli-version-checker": "2.1.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "requires": {
+            "resolve": "1.5.0",
+            "semver": "5.4.1"
+          }
+        }
+      }
+    },
+    "ember-getowner-polyfill": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
+      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
+      "requires": {
+        "ember-cli-version-checker": "2.1.0",
+        "ember-factory-for-polyfill": "1.3.1"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "requires": {
+            "resolve": "1.5.0",
+            "semver": "5.4.1"
+          }
+        }
+      }
+    },
     "ember-load-initializers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz",
       "integrity": "sha1-SRnq8G9t/sp+E0Yz2MBabJkh5uc=",
       "dev": true,
       "requires": {
+        "ember-cli-babel": "6.10.0"
+      }
+    },
+    "ember-native-dom-helpers": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.10.tgz",
+      "integrity": "sha512-bPJX49vlgnBGwFn/3WJPPJjjyd7/atvzW5j01u1dbyFf3bXvHg9Rs1qaZJdk8js0qZ1FINadIEC9vWtgN3w7tg==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "1.2.0",
         "ember-cli-babel": "6.10.0"
       }
     },
@@ -4820,6 +4870,910 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -6538,6 +7492,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true,
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-native-dom-helpers": "^0.5.10",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.17.0",
     "ember-wait-for-test-helper": "0.1.1",

--- a/tests/acceptance/infinity-test.js
+++ b/tests/acceptance/infinity-test.js
@@ -1,0 +1,63 @@
+import { test } from 'qunit';
+import { findAll } from 'ember-native-dom-helpers';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | infinity-scrollable', {
+  beforeEach() {
+    // bring testem window up to the top.
+    document.getElementById('ember-testing-container').scrollTop = 0;
+  }
+});
+
+test('IntersectionObserver Component fetches more data when scrolled into viewport', function(assert) {
+  visit('/infinity-scrollable');
+
+  andThen(() => {
+    assert.equal(findAll('.infinity-svg').length, 10);
+    assert.equal(findAll('.infinity-scrollable.inactive').length, 1, 'component is inactive before fetching more data');
+    document.querySelector('.infinity-scrollable').scrollIntoView();
+  });
+
+  waitFor('.infinity-scrollable.inactive');
+
+  andThen(() => {
+    assert.equal(findAll('.infinity-svg').length, 20);
+    assert.equal(findAll('.infinity-scrollable.inactive').length, 1, 'component is inactive after fetching more data');
+  });
+});
+
+test('rAF Component fetches more data when scrolled into viewport', function(assert) {
+  visit('/infinity-scrollable-raf');
+
+  andThen(() => {
+    assert.equal(findAll('.infinity-svg-rAF').length, 10);
+    assert.equal(findAll('.infinity-scrollable-rAF.inactive').length, 1, 'component is inactive before fetching more data');
+    document.querySelector('.infinity-scrollable-rAF').scrollIntoView();
+  });
+
+  waitFor('.infinity-scrollable-rAF.inactive');
+
+  andThen(() => {
+    assert.equal(findAll('.infinity-svg-rAF').length, 20);
+    assert.equal(findAll('.infinity-scrollable-rAF.inactive').length, 1, 'component is inactive after fetching more data');
+  });
+});
+
+test('scrollEvent Component fetches more data when scrolled into viewport', function(assert) {
+  visit('/infinity-scrollable-scrollevent');
+
+  andThen(() => {
+    assert.equal(findAll('.infinity-svg-scrollEvent').length, 10);
+    assert.equal(findAll('.infinity-scrollable-scrollEvent.inactive').length, 1, 'component is inactive before fetching more data');
+    document.querySelector('.infinity-scrollable-scrollEvent').scrollIntoView();
+  });
+
+  waitFor(() => {
+    return find('.infinity-svg-scrollEvent').length === 20;
+  });
+
+  andThen(() => {
+    assert.equal(findAll('.infinity-svg-scrollEvent').length, 20);
+    // assert.equal(find('.infinity-scrollable-scrollEvent.inactive').length, 1, 'component is inactive after fetching more data');
+  });
+});

--- a/tests/acceptance/infinity-test.js
+++ b/tests/acceptance/infinity-test.js
@@ -61,8 +61,13 @@ test('scrollEvent Component fetches more data when scrolled into viewport', func
     assert.equal(find('.infinity-scrollable-scrollEvent.active').length, 1, 'component is still active after fetching more data');
     // scroll 1px to trigger inactive state
     let elem = document.getElementsByClassName('list-scrollEvent')[0];
-    elem.scrollTop = elem.scrollTop + 1;
+    elem.scrollTop = elem.scrollTop + 5;
   });
+
+  waitFor(() => {
+    return find('.infinity-scrollable-scrollEvent.inactive').length, 1;
+  });
+
   andThen(() => {
     assert.equal(find('.infinity-scrollable-scrollEvent.inactive').length, 1, 'component is inactive after scrolling');
   });

--- a/tests/acceptance/infinity-test.js
+++ b/tests/acceptance/infinity-test.js
@@ -58,6 +58,12 @@ test('scrollEvent Component fetches more data when scrolled into viewport', func
 
   andThen(() => {
     assert.equal(findAll('.infinity-svg-scrollEvent').length, 20);
-    // assert.equal(find('.infinity-scrollable-scrollEvent.inactive').length, 1, 'component is inactive after fetching more data');
+    assert.equal(find('.infinity-scrollable-scrollEvent.active').length, 1, 'component is still active after fetching more data');
+    // scroll 1px to trigger inactive state
+    let elem = document.getElementsByClassName('list-scrollEvent')[0];
+    elem.scrollTop = elem.scrollTop + 1;
+  });
+  andThen(() => {
+    assert.equal(find('.infinity-scrollable-scrollEvent.inactive').length, 1, 'component is inactive after scrolling');
   });
 });

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -1,7 +1,13 @@
 import { test } from 'qunit';
+import { find } from 'ember-native-dom-helpers';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
-moduleForAcceptance('Acceptance | integration');
+moduleForAcceptance('Acceptance | integration', {
+  beforeEach() {
+    // bring testem window up to the top.
+    document.getElementById('ember-testing-container').scrollTop = 0;
+  }
+});
 
 test('Component is active when in viewport', function(assert) {
   assert.expect(1);
@@ -9,7 +15,7 @@ test('Component is active when in viewport', function(assert) {
   visit('/');
 
   andThen(() => {
-    assert.ok(find('.my-component.top.start-enabled.active').length);
+    assert.ok(find('.my-component.top.start-enabled.active'), 'component is active');
   });
 });
 
@@ -19,23 +25,24 @@ test('Component is inactive when not in viewport', function(assert) {
   visit('/');
 
   andThen(() => {
-    assert.ok(find('.my-component.bottom.inactive').length);
+    assert.ok(find('.my-component.bottom.inactive'), 'component is inactive');
   });
 });
 
 test('Component moves to active when scrolled into viewport', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   visit('/');
 
   andThen(() => {
-    find('.my-component.bottom').get(0).scrollIntoView();
+    assert.ok(find('.my-component.bottom.inactive'), 'component is inactive');
+    document.querySelector('.my-component.bottom').scrollIntoView();
   });
 
   waitFor('.my-component.bottom.active');
 
   andThen(() => {
-    assert.ok(find('.my-component.bottom.active').length);
+    assert.ok(find('.my-component.bottom.active'), 'component is active');
   });
 });
 
@@ -45,13 +52,13 @@ test('Component moves back to inactive when scrolled out of viewport', function(
   visit('/');
 
   andThen(() => {
-    find(window).scrollTop(2000);
+    document.querySelector('.my-component.bottom').scrollIntoView();
   });
 
   waitFor('.my-component.top.start-enabled.inactive');
 
   andThen(() => {
-    assert.ok(find('.my-component.top.start-enabled.inactive').length);
+    assert.ok(find('.my-component.top.start-enabled.inactive'), 'component is inactive');
   });
 });
 
@@ -61,6 +68,6 @@ test('Component can be disabled', function(assert) {
   visit('/');
 
   andThen(() => {
-    assert.ok(find('.my-component.top.start-disabled.inactive').length);
+    assert.ok(find('.my-component.top.start-disabled.inactive'), 'component is inactive');
   });
 });

--- a/tests/dummy/app/components/my-component.js
+++ b/tests/dummy/app/components/my-component.js
@@ -1,11 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
+import { on } from '@ember/object/evented';
+import { setProperties, getProperties, get } from '@ember/object';
 import InViewportMixin from 'ember-in-viewport';
-
-const {
-  Component,
-  on,
-  getProperties, setProperties
-} = Ember;
 
 export default Component.extend(InViewportMixin, {
   classNames: ['my-component'],
@@ -16,10 +12,16 @@ export default Component.extend(InViewportMixin, {
 
     let {
       viewportSpyOverride,
-      viewportEnabledOverride
+      viewportEnabledOverride,
+      viewportIntersectionObserverOverride,
+      viewportRAFOverride,
+      scrollableAreaOverride
     } = getProperties(this,
       'viewportSpyOverride',
-      'viewportEnabledOverride'
+      'viewportEnabledOverride',
+      'viewportIntersectionObserverOverride',
+      'viewportRAFOverride',
+      'scrollableAreaOverride'
     );
 
     if (viewportSpyOverride !== undefined) {
@@ -28,7 +30,22 @@ export default Component.extend(InViewportMixin, {
     if (viewportEnabledOverride !== undefined) {
       options.viewportEnabled = viewportEnabledOverride;
     }
+    if (viewportIntersectionObserverOverride !== undefined) {
+      options.viewportUseIntersectionObserver = viewportIntersectionObserverOverride;
+    }
+    if (viewportRAFOverride !== undefined) {
+      options.viewportUseRAF = viewportRAFOverride;
+    }
+    if (scrollableAreaOverride !== undefined) {
+      options.scrollableArea = scrollableAreaOverride;
+    }
 
     setProperties(this, options);
-  })
+  }),
+
+  didEnterViewport() {
+    if (get(this, 'infinityLoad')) {
+      get(this, 'infinityLoad')();
+    }
+  }
 });

--- a/tests/dummy/app/controllers/infinity-scrollable-raf.js
+++ b/tests/dummy/app/controllers/infinity-scrollable-raf.js
@@ -1,0 +1,4 @@
+import ScrollableController from './infinity-scrollable';
+
+export default ScrollableController.extend({
+});

--- a/tests/dummy/app/controllers/infinity-scrollable-scrollevent.js
+++ b/tests/dummy/app/controllers/infinity-scrollable-scrollevent.js
@@ -1,0 +1,4 @@
+import ScrollableController from './infinity-scrollable';
+
+export default ScrollableController.extend({
+});

--- a/tests/dummy/app/controllers/infinity-scrollable.js
+++ b/tests/dummy/app/controllers/infinity-scrollable.js
@@ -1,0 +1,18 @@
+import Controller from '@ember/controller';
+import { set, get } from '@ember/object';
+
+let rect = '<rect x="10" y="10" width="30" height="30" stroke="black" fill="transparent" stroke-width="5"/>';
+let circle = '<circle cx="25" cy="75" r="20" stroke="red" fill="transparent" stroke-width="5"/>';
+let line = '<line x1="10" x2="50" y1="110" y2="150" stroke="orange" stroke-width="5"/>';
+
+const images = [rect, circle, line];
+
+export default Controller.extend({
+  actions: {
+    infinityLoad() {
+      const newModels = [...Array(10).fill().map(() => `${images[(Math.random() * images.length) | 0]}`)];
+      get(this, 'model').push(...newModels);
+      set(this, 'model', Array.from(get(this, 'model')));
+    }
+  }
+});

--- a/tests/dummy/app/controllers/infinity.js
+++ b/tests/dummy/app/controllers/infinity.js
@@ -1,0 +1,18 @@
+import Controller from '@ember/controller';
+import { set, get } from '@ember/object';
+
+const images = ["jarjan", "aio___", "kushsolitary", "kolage", "idiot", "gt"];
+
+const models = [...Array(10).fill().map(() => `https://s3.amazonaws.com/uifaces/faces/twitter/${images[(Math.random() * images.length) | 0]}/128.jpg`)];
+
+export default Controller.extend({
+  models,
+
+  actions: {
+    infinityLoad() {
+      const newModels = [...Array(10).fill().map(() => `https://s3.amazonaws.com/uifaces/faces/twitter/${images[(Math.random() * images.length) | 0]}/128.jpg`)];
+      get(this, 'models').push(...newModels);
+      set(this, 'models', Array.from(get(this, 'models')));
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,10 @@ const Router = EmberRouter.extend({
 });
 
 Router.map(function() {
+  this.route('infinity');
+  this.route('infinity-scrollable');
+  this.route('infinity-scrollable-raf');
+  this.route('infinity-scrollable-scrollevent');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/infinity-scrollable-raf.js
+++ b/tests/dummy/app/routes/infinity-scrollable-raf.js
@@ -1,0 +1,4 @@
+import ScrollableRoute from './infinity-scrollable';
+
+export default ScrollableRoute.extend({
+});

--- a/tests/dummy/app/routes/infinity-scrollable-scrollevent.js
+++ b/tests/dummy/app/routes/infinity-scrollable-scrollevent.js
@@ -1,0 +1,4 @@
+import ScrollableRoute from './infinity-scrollable';
+
+export default ScrollableRoute.extend({
+});

--- a/tests/dummy/app/routes/infinity-scrollable.js
+++ b/tests/dummy/app/routes/infinity-scrollable.js
@@ -1,5 +1,4 @@
 import Route from '@ember/routing/route';
-import { set } from '@ember/object';
 
 let rect = '<rect x="10" y="10" width="30" height="30" stroke="black" fill="transparent" stroke-width="5"/>';
 let circle = '<circle cx="25" cy="75" r="20" stroke="red" fill="transparent" stroke-width="5"/>';
@@ -10,8 +9,5 @@ const images = [rect, circle, line];
 export default Route.extend({
   model() {
     return [...Array(10).fill().map(() => `${images[(Math.random() * images.length) | 0]}`)];
-  },
-  setupController(controller, model) {
-    set(controller, 'model', model);
   }
 });

--- a/tests/dummy/app/routes/infinity-scrollable.js
+++ b/tests/dummy/app/routes/infinity-scrollable.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+import { set } from '@ember/object';
+
+let rect = '<rect x="10" y="10" width="30" height="30" stroke="black" fill="transparent" stroke-width="5"/>';
+let circle = '<circle cx="25" cy="75" r="20" stroke="red" fill="transparent" stroke-width="5"/>';
+let line = '<line x1="10" x2="50" y1="110" y2="150" stroke="orange" stroke-width="5"/>';
+
+const images = [rect, circle, line];
+
+export default Route.extend({
+  model() {
+    return [...Array(10).fill().map(() => `${images[(Math.random() * images.length) | 0]}`)];
+  },
+  setupController(controller, model) {
+    set(controller, 'model', model);
+  }
+});

--- a/tests/dummy/app/routes/infinity.js
+++ b/tests/dummy/app/routes/infinity.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,12 +1,9 @@
 <div>
-  {{#my-component class="top start-enabled"
-    viewportSpyOverride=true
-  }}
+  {{#my-component class="top start-enabled"}}
     <p>Starts enabled</p>
   {{/my-component}}
 
   {{#my-component class="top start-disabled"
-    viewportSpyOverride=true
     viewportEnabledOverride=false
   }}
     <p>Starts disabled</p>
@@ -14,7 +11,11 @@
 </div>
 
 <div class="hide-me">
-  {{#my-component class="bottom"}}
+  {{#my-component 
+    viewportSpyOverride=true
+    viewportIntersectionObserverOverride=false
+    class="bottom"
+  }}
     <p>Hi!</p>
   {{/my-component}}
 </div>

--- a/tests/dummy/app/templates/infinity-scrollable-raf.hbs
+++ b/tests/dummy/app/templates/infinity-scrollable-raf.hbs
@@ -1,0 +1,17 @@
+<div class="list-rAF" style="height: 500px; overflow: scroll;">
+  <ul>
+    {{#each model as |val|}}
+    <div class="infinity-svg-rAF">
+      <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        {{{val}}}
+      </svg>
+    </div>
+    {{/each}}
+  </ul>
+  {{my-component 
+    class="infinity-scrollable-rAF" 
+    viewportSpyOverride=true
+    viewportIntersectionObserverOverride=false
+    scrollableAreaOverride=".list-rAF"
+    infinityLoad=(action "infinityLoad")}}
+</div>

--- a/tests/dummy/app/templates/infinity-scrollable-scrollevent.hbs
+++ b/tests/dummy/app/templates/infinity-scrollable-scrollevent.hbs
@@ -8,8 +8,8 @@
     </div>
     {{/each}}
   </ul>
-  {{my-component 
-    class="infinity-scrollable-scrollEvent" 
+  {{my-component
+    class="infinity-scrollable-scrollEvent"
     viewportSpyOverride=true
     viewportIntersectionObserverOverride=false
     viewportRAFOverride=false

--- a/tests/dummy/app/templates/infinity-scrollable-scrollevent.hbs
+++ b/tests/dummy/app/templates/infinity-scrollable-scrollevent.hbs
@@ -1,0 +1,18 @@
+<div class="list-scrollEvent" style="height: 500px; overflow: scroll;">
+  <ul>
+    {{#each model as |val|}}
+    <div class="infinity-svg-scrollEvent">
+      <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        {{{val}}}
+      </svg>
+    </div>
+    {{/each}}
+  </ul>
+  {{my-component 
+    class="infinity-scrollable-scrollEvent" 
+    viewportSpyOverride=true
+    viewportIntersectionObserverOverride=false
+    viewportRAFOverride=false
+    scrollableAreaOverride=".list-scrollEvent"
+    infinityLoad=(action "infinityLoad")}}
+</div>

--- a/tests/dummy/app/templates/infinity-scrollable.hbs
+++ b/tests/dummy/app/templates/infinity-scrollable.hbs
@@ -1,0 +1,15 @@
+<div class="list" style="height: 500px; overflow: scroll;">
+  <ul>
+    {{#each model as |val|}}
+    <div class="infinity-svg">
+      <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        {{{val}}}
+      </svg>
+    </div>
+    {{/each}}
+  </ul>
+  {{my-component 
+    class="infinity-scrollable" 
+    scrollableAreaOverride=".list"
+    infinityLoad=(action "infinityLoad")}}
+</div>

--- a/tests/dummy/app/templates/infinity-scrollable.hbs
+++ b/tests/dummy/app/templates/infinity-scrollable.hbs
@@ -1,15 +1,15 @@
 <div class="list" style="height: 500px; overflow: scroll;">
   <ul>
     {{#each model as |val|}}
-    <div class="infinity-svg">
-      <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
-        {{{val}}}
-      </svg>
-    </div>
+      <div class="infinity-svg">
+        <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+          {{{val}}}
+        </svg>
+      </div>
     {{/each}}
   </ul>
-  {{my-component 
-    class="infinity-scrollable" 
+  {{my-component
+    class="infinity-scrollable"
     scrollableAreaOverride=".list"
     infinityLoad=(action "infinityLoad")}}
 </div>

--- a/tests/dummy/app/templates/infinity.hbs
+++ b/tests/dummy/app/templates/infinity.hbs
@@ -1,0 +1,8 @@
+<ul>
+  {{#each models as |val|}}
+    <li><img src={{val}} /></li>
+  {{/each}}
+</ul>
+{{my-component 
+  class="infinity-component" 
+  infinityLoad=(action "infinityLoad")}}

--- a/tests/unit/initializers/viewport-config-test.js
+++ b/tests/unit/initializers/viewport-config-test.js
@@ -24,4 +24,6 @@ test('it has a viewportConfig object', function(assert) {
 
   assert.ok(viewportConfig);
   assert.ok(viewportConfigKeys.length);
+  assert.ok(viewportConfigKeys.includes('intersectionThreshold'), 'intersectionThreshold is in viewportConfig');
+  assert.ok(viewportConfigKeys.includes('scrollableArea'), 'scrollableArea is in viewportConfig');
 });


### PR DESCRIPTION
## IntersectionObserver API

This PR provides an easy upgrade path to use IntersectionObserver.  This also doesn't have any effect on existing users and will fallback to rAF if not in target browser.

Also added two routes - `infinity` and `infinity-scrollable` to perf-test and test.

- [x] use IntersectionOverride by default
- [x] allow for scrollable area (a configuration option on the IntersectionObserver)
- [x] tests (including separate tests for IntersectionObserver, rAF and scrollEvent)
- [x] documentation

close #106 #67 
Ref prev PR #112 
Partial Fix #37 