### PR TITLE
Upgrade to 3.0 and remove jquery usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,15 +43,6 @@ module.exports = {
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
         // add your custom rules and overrides for node files here
       })
-    },
-
-    // test files
-    {
-      files: ['tests/**/*.js'],
-      excludedFiles: ['tests/dummy/**/*.js'],
-      env: {
-        embertest: true
-      }
     }
   ]
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,10 +4,55 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module'
   },
-  extends: 'eslint:recommended',
+  plugins: [
+    'ember'
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:ember/recommended'
+  ],
   env: {
     browser: true
   },
   rules: {
-  }
+    // 'ember/no-on-calls-in-components': 0
+  },
+  overrides: [
+    // node files
+    {
+      files: [
+        'index.js',
+        'testem.js',
+        'ember-cli-build.js',
+        'config/**/*.js',
+        'tests/dummy/config/**/*.js'
+      ],
+      excludedFiles: [
+        'app/**',
+        'addon/**',
+        'tests/dummy/app/**'
+      ],
+      parserOptions: {
+        sourceType: 'script',
+        ecmaVersion: 2015
+      },
+      env: {
+        browser: false,
+        node: true
+      },
+      plugins: ['node'],
+      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+        // add your custom rules and overrides for node files here
+      })
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      excludedFiles: ['tests/dummy/**/*.js'],
+      env: {
+        embertest: true
+      }
+    }
+  ]
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
     browser: true
   },
   rules: {
-    // 'ember/no-on-calls-in-components': 0
   },
   overrides: [
     // node files

--- a/.npmignore
+++ b/.npmignore
@@ -7,8 +7,8 @@
 .bowerrc
 .editorconfig
 .ember-cli
-.gitignore
 .eslintrc.js
+.gitignore
 .watchmanconfig
 .travis.yml
 bower.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "8"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:
@@ -37,7 +37,7 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g npm@4
+  - npm install -g npm@5
   - npm --version
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "4"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:
@@ -41,7 +41,6 @@ before_install:
   - npm --version
 
 script:
-  - npm run lint:js
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ before_install:
   - npm --version
 
 script:
-  - npm run lint:js
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "4"
 
-sudo: required
+sudo: false
 dist: trusty
 
 addons:
@@ -41,6 +41,7 @@ before_install:
   - npm --version
 
 script:
+  - npm run lint:js
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "4"
 
-sudo: required
+sudo: false
 dist: trusty
 
 addons:
@@ -22,9 +22,9 @@ env:
   matrix:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-lts-2.8
     - EMBER_TRY_SCENARIO=ember-lts-2.12
     - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-lts-2.18
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
@@ -41,6 +41,7 @@ before_install:
   - npm --version
 
 script:
+  - npm run lint:js
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ The mixin comes with some options. Due to the way listeners and `IntersectionObs
 
 ```js
 export default Ember.Component.extend(InViewportMixin, {
-  viewportOptionsOverride: Ember.on('didInsertElement', function() {
+  init() {
+    this._super(...arguments);
+
     Ember.setProperties(this, {
       viewportEnabled                 : true,
       viewportUseRAF                  : true,
@@ -93,7 +95,7 @@ export default Ember.Component.extend(InViewportMixin, {
         right  : 20
       }
     });
-  })
+  }
 });
 ```
 

--- a/addon/initializers/viewport-config.js
+++ b/addon/initializers/viewport-config.js
@@ -7,8 +7,8 @@ const defaultConfig = {
   viewportScrollSensitivity: 1,
   viewportRefreshRate: 100,
   viewportListeners: [
-    { context: window, event: 'scroll.scrollable' },
-    { context: window, event: 'resize.resizable' }
+    { context: window, event: 'scroll' },
+    { context: window, event: 'resize' }
   ],
   viewportTolerance: {
     top: 0,
@@ -23,7 +23,7 @@ const defaultConfig = {
 if (canUseDOM) {
   defaultConfig.viewportListeners.push({
     context: document,
-    event: 'touchmove.scrollable'
+    event: 'touchmove'
   });
 }
 

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -139,6 +139,10 @@ export default Mixin.create({
    * @param {Array} - entries
    */
   _onIntersection(entries) {
+    if (this.isDestroyed || this.isDestroying) {
+      return;
+    }
+
     const entry = entries[0];
 
     if (entry.isIntersecting) {

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -223,7 +223,7 @@ export default Mixin.create({
     assert('sensitivity cannot be 0', sensitivity);
 
     const contextEl = get(this, 'scrollableArea') || window;
-    let elem = findElem(contextEl);
+    const elem = findElem(contextEl);
 
     elem.addEventListener('scroll', () => {
       this._debouncedEventHandler('_triggerDidScrollDirection', elem, sensitivity);
@@ -232,9 +232,8 @@ export default Mixin.create({
 
   _unbindScrollDirectionListener() {
     const elementId = get(this, 'elementId');
-
     const context = get(this, 'scrollableArea') || window;
-    let elem = findElem(context);
+    const elem = findElem(context);
 
     elem.removeEventListener('scroll', () => {
       this._debouncedEventHandler('_triggerDidScrollDirection', elem, get(this, 'viewportScrollSensitivity'));
@@ -267,8 +266,8 @@ export default Mixin.create({
     get(this, 'viewportListeners').forEach((listener) => {
       let { context, event } = listener;
       context = get(this, 'scrollableArea') || context;
-
       let elem = findElem(context);
+
       elem.removeEventListener(event, () => {
         this._debouncedEventHandler('_setViewportEntered');
       });

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -8,6 +8,7 @@ import { not } from '@ember/object/computed';
 import { getOwner } from '@ember/application';
 import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
 import canUseRAF from 'ember-in-viewport/utils/can-use-raf';
+import findElem from 'ember-in-viewport/utils/find-elem';
 import canUseIntersectionObserver from 'ember-in-viewport/utils/can-use-intersection-observer';
 import isInViewport from 'ember-in-viewport/utils/is-in-viewport';
 import checkScrollDirection from 'ember-in-viewport/utils/check-scroll-direction';
@@ -218,7 +219,7 @@ export default Mixin.create({
     assert('sensitivity cannot be 0', sensitivity);
 
     const contextEl = get(this, 'scrollableArea') || window;
-    let elem = this._findElem(contextEl);
+    let elem = findElem(contextEl);
 
     elem.addEventListener('scroll', () => {
       this._debouncedEventHandler('_triggerDidScrollDirection', elem, sensitivity);
@@ -229,7 +230,7 @@ export default Mixin.create({
     const elementId = get(this, 'elementId');
 
     const context = get(this, 'scrollableArea') || window;
-    let elem = this._findElem(context);
+    let elem = findElem(context);
 
     elem.removeEventListener('scroll', () => {
       this._debouncedEventHandler('_triggerDidScrollDirection', elem, get(this, 'viewportScrollSensitivity'));
@@ -242,7 +243,7 @@ export default Mixin.create({
     assert('You must pass a valid context to _bindListeners', context);
     assert('You must pass a valid event to _bindListeners', event);
 
-    let elem = this._findElem(context);
+    let elem = findElem(context);
 
     elem.addEventListener(event, () => {
       this._debouncedEventHandler('_setViewportEntered');
@@ -263,7 +264,7 @@ export default Mixin.create({
       let { context, event } = listener;
       context = get(this, 'scrollableArea') || context;
 
-      let elem = this._findElem(context);
+      let elem = findElem(context);
       elem.removeEventListener(event, () => {
         this._debouncedEventHandler('_setViewportEntered');
       });
@@ -271,19 +272,4 @@ export default Mixin.create({
 
     this._unbindScrollDirectionListener();
   },
-
-  _findElem(context) {
-    let elem;
-    if (
-      context.nodeType === Node.ELEMENT_NODE ||
-      context.nodeType === Node.DOCUMENT_NODE ||
-      context instanceof Window
-    ) {
-      elem = context
-    } else {
-      elem = document.querySelector(context);
-    }
-
-    return elem;
-  }
 });

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -2,7 +2,6 @@ import { assign } from '@ember/polyfills';
 import Mixin from '@ember/object/mixin';
 import { typeOf } from '@ember/utils';
 import { assert } from '@ember/debug';
-import $ from 'jquery';
 import { set, get, setProperties } from '@ember/object';
 import { next, bind, debounce, scheduleOnce } from '@ember/runloop';
 import { not } from '@ember/object/computed';
@@ -98,6 +97,8 @@ export default Mixin.create({
     }
 
     if (get(this, 'viewportUseIntersectionObserver')) {
+      // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+      // IntersectionObserver takes either a Document Element or null for `root`
       const { top = 0, left = 0, bottom = 0, right = 0 } = this.viewportTolerance;
       const options = {
         root: scrollableArea,
@@ -108,15 +109,16 @@ export default Mixin.create({
       this.intersectionObserver = new IntersectionObserver(bind(this, this._onIntersection), options);
       this.intersectionObserver.observe(element);
     } else {
-      const $contextEl = scrollableArea ? $(scrollableArea) : $(window);
+      const height = scrollableArea ? scrollableArea.offsetHeight : window.innerHeight;
+      const width = scrollableArea ? scrollableArea.offsetWidth : window.innerWidth;
       const boundingClientRect = element.getBoundingClientRect();
 
       if (boundingClientRect) {
         this._triggerDidAccessViewport(
           isInViewport(
             boundingClientRect,
-            $contextEl.innerHeight(),
-            $contextEl.innerWidth(),
+            height,
+            width,
             get(this, 'viewportTolerance')
           )
         );
@@ -147,16 +149,16 @@ export default Mixin.create({
     }
   },
 
-  _triggerDidScrollDirection($contextEl = null, sensitivity = 1) {
-    assert('You must pass a valid context element to _triggerDidScrollDirection', $contextEl);
+  _triggerDidScrollDirection(contextEl = null, sensitivity = 1) {
+    assert('You must pass a valid context element to _triggerDidScrollDirection', contextEl);
     assert('sensitivity cannot be 0', sensitivity);
 
     const elementId = get(this, 'elementId');
     const lastDirectionForEl = lastDirection[elementId];
     const lastPositionForEl = lastPosition[elementId];
     const newPosition = {
-      top: $contextEl.scrollTop(),
-      left: $contextEl.scrollLeft()
+      top: contextEl.scrollTop,
+      left: contextEl.scrollLeft
     };
 
     const scrollDirection = checkScrollDirection(lastPositionForEl, newPosition, sensitivity);
@@ -215,10 +217,11 @@ export default Mixin.create({
   _bindScrollDirectionListener(sensitivity = 1) {
     assert('sensitivity cannot be 0', sensitivity);
 
-    const $contextEl = get(this, 'scrollableArea') ? $(get(this, 'scrollableArea')) : $(window);
+    const contextEl = get(this, 'scrollableArea') || window;
+    let elem = this._findElem(contextEl);
 
-    $contextEl.on(`scroll.directional#${get(this, 'elementId')}`, () => {
-      this._debouncedEventHandler('_triggerDidScrollDirection', $contextEl, sensitivity);
+    elem.addEventListener('scroll', () => {
+      this._debouncedEventHandler('_triggerDidScrollDirection', elem, sensitivity);
     });
   },
 
@@ -226,8 +229,11 @@ export default Mixin.create({
     const elementId = get(this, 'elementId');
 
     const context = get(this, 'scrollableArea') || window;
+    let elem = this._findElem(context);
 
-    $(context).off(`scroll.directional#${elementId}`);
+    elem.removeEventListener('scroll', () => {
+      this._debouncedEventHandler('_triggerDidScrollDirection', elem, get(this, 'viewportScrollSensitivity'));
+    });
     delete lastPosition[elementId];
     delete lastDirection[elementId];
   },
@@ -236,8 +242,10 @@ export default Mixin.create({
     assert('You must pass a valid context to _bindListeners', context);
     assert('You must pass a valid event to _bindListeners', event);
 
-    $(context).on(`${event}.${get(this, 'elementId')}`, () => {
-      this._debouncedEventHandler('_setViewportEntered', context);
+    let elem = this._findElem(context);
+
+    elem.addEventListener(event, () => {
+      this._debouncedEventHandler('_setViewportEntered');
     });
   },
 
@@ -253,10 +261,29 @@ export default Mixin.create({
 
     get(this, 'viewportListeners').forEach((listener) => {
       let { context, event } = listener;
-      context = get(this, 'scrollableArea') ? get(this, 'scrollableArea') : context;
-      $(context).off(`${event}.${elementId}`);
+      context = get(this, 'scrollableArea') || context;
+
+      let elem = this._findElem(context);
+      elem.removeEventListener(event, () => {
+        this._debouncedEventHandler('_setViewportEntered');
+      });
     });
 
     this._unbindScrollDirectionListener();
+  },
+
+  _findElem(context) {
+    let elem;
+    if (
+      context.nodeType === Node.ELEMENT_NODE ||
+      context.nodeType === Node.DOCUMENT_NODE ||
+      context instanceof Window
+    ) {
+      elem = context
+    } else {
+      elem = document.querySelector(context);
+    }
+
+    return elem;
   }
 });

--- a/addon/utils/find-elem.js
+++ b/addon/utils/find-elem.js
@@ -1,0 +1,14 @@
+export default function(context) {
+  let elem;
+  if (
+    context.nodeType === Node.ELEMENT_NODE ||
+    context.nodeType === Node.DOCUMENT_NODE ||
+    context instanceof Window
+  ) {
+    elem = context
+  } else {
+    elem = document.querySelector(context);
+  }
+
+  return elem;
+}

--- a/app/initializers/viewport-config.js
+++ b/app/initializers/viewport-config.js
@@ -1,2 +1,1 @@
 export { default, initialize } from 'ember-in-viewport/initializers/viewport-config';
-

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   scenarios: [
     {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,90 +1,70 @@
-module.exports = {
-  scenarios: [
-    {
-      name: 'ember-lts-2.8',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-8'
+'use strict';
+
+const getChannelURL = require('ember-source-channel-url');
+
+module.exports = function() {
+  return Promise.all([
+    getChannelURL('release'),
+    getChannelURL('beta'),
+    getChannelURL('canary'),
+  ]).then((urls) => {
+    return {
+      scenarios: [
+        {
+          name: 'ember-lts-2.12',
+          npm: {
+            devDependencies: {
+              'ember-source': '~2.12.0'
+            }
+          }
         },
-        resolutions: {
-          'ember': 'lts-2-8'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-lts-2.12',
-      npm: {
-        devDependencies: {
-          'ember-source': '~2.12.0'
-        }
-      }
-    },
-    {
-      name: 'ember-lts-2.16',
-      npm: {
-        devDependencies: {
-          'ember-source': '~2.16.0'
-        }
-      }
-    },
-    {
-      name: 'ember-release',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#release'
+        {
+          name: 'ember-lts-2.16',
+          npm: {
+            devDependencies: {
+              'ember-source': '~2.16.0'
+            }
+          }
         },
-        resolutions: {
-          'ember': 'release'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-beta',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
+        {
+          name: 'ember-lts-2.18',
+          npm: {
+            devDependencies: {
+              'ember-source': '~2.18.0'
+            }
+          }
         },
-        resolutions: {
-          'ember': 'beta'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-canary',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
+        {
+          name: 'ember-release',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[0]
+            }
+          }
         },
-        resolutions: {
-          'ember': 'canary'
+        {
+          name: 'ember-beta',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[1]
+            }
+          }
+        },
+        {
+          name: 'ember-canary',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[2]
+            }
+          }
+        },
+        {
+          name: 'ember-default',
+          npm: {
+            devDependencies: {}
+          }
         }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-default',
-      npm: {
-        devDependencies: {}
-      }
-    }
-  ]
+      ]
+    };
+  });
 };

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -14,7 +14,8 @@ module.exports = function() {
           name: 'ember-lts-2.12',
           npm: {
             devDependencies: {
-              'ember-source': '~2.12.0'
+              'ember-source': '~2.12.0',
+              'ember-native-dom-event-dispatcher': null
             }
           }
         },
@@ -22,7 +23,8 @@ module.exports = function() {
           name: 'ember-lts-2.16',
           npm: {
             devDependencies: {
-              'ember-source': '~2.16.0'
+              'ember-source': '~2.16.0',
+              'ember-native-dom-event-dispatcher': null
             }
           }
         },

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,9 +4,6 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    'ember-cli-babel': {
-      includePolyfill: true,
-    }
     // Add options here
   });
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,9 +3,12 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  let app = new EmberAddon(defaults, {
-    vendorFiles: { 'jquery.js': null }
-  });
+  let project = defaults.project;
+  let options = {};
+  if (project.findAddonByName('ember-native-dom-event-dispatcher')) {
+    options.vendorFiles = { 'jquery.js': null };
+  }
+  let app = new EmberAddon(defaults, options);
 
   /*
     This build file specifies the options for the dummy test app of this

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    vendorFiles: { 'jquery.js': null }
   });
 
   /*

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,10 +1,12 @@
-/* eslint-env node */
 'use strict';
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
+    babel: {
+      includePolyfill: true,
+    }
     // Add options here
   });
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    babel: {
+    'ember-cli-babel': {
       includePolyfill: true,
     }
     // Add options here

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,12 @@
         "@glimmer/di": "0.2.0"
       }
     },
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -289,6 +295,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -1293,6 +1305,12 @@
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
     },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
+    },
     "body": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
@@ -1428,29 +1446,6 @@
         "json-stable-stringify": "1.0.1",
         "rsvp": "3.6.2",
         "workerpool": "2.3.0"
-      }
-    },
-    "broccoli-brocfile-loader": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/broccoli-brocfile-loader/-/broccoli-brocfile-loader-0.18.0.tgz",
-      "integrity": "sha1-LoYCHIBcNP/I0povtyHPJz6Bnks=",
-      "dev": true,
-      "requires": {
-        "findup-sync": "0.4.3"
-      },
-      "dependencies": {
-        "findup-sync": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
-          "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
-          "dev": true,
-          "requires": {
-            "detect-file": "0.1.0",
-            "is-glob": "2.0.1",
-            "micromatch": "2.3.11",
-            "resolve-dir": "0.1.1"
-          }
-        }
       }
     },
     "broccoli-builder": {
@@ -1935,6 +1930,12 @@
         "node-int64": "0.4.0"
       }
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
     "builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
@@ -1978,6 +1979,21 @@
         }
       }
     },
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "dev": true,
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      }
+    },
     "calculate-cache-key-for-tree": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.1.0.tgz",
@@ -2014,6 +2030,24 @@
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true,
       "optional": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        }
+      }
     },
     "can-symlink": {
       "version": "1.0.0",
@@ -2250,6 +2284,12 @@
         "restore-cursor": "1.0.1"
       }
     },
+    "cli-spinners": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
+      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
+      "dev": true
+    },
     "cli-table": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
@@ -2265,17 +2305,6 @@
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
           "dev": true
         }
-      }
-    },
-    "cli-table2": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
-      "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
-      "dev": true,
-      "requires": {
-        "colors": "1.1.2",
-        "lodash": "3.10.1",
-        "string-width": "1.0.2"
       }
     },
     "cli-width": {
@@ -2300,6 +2329,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
       "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "1.0.0"
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -2337,13 +2375,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true,
-      "optional": true
     },
     "commander": {
       "version": "2.12.1",
@@ -2469,234 +2500,6 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
-    },
-    "console-ui": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/console-ui/-/console-ui-2.0.1.tgz",
-      "integrity": "sha1-VtByHrzETmycPeAvNV+JirpB6nk=",
-      "dev": true,
-      "requires": {
-        "chalk": "2.3.0",
-        "inquirer": "2.0.0",
-        "ora": "1.3.0",
-        "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "cli-spinners": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-          "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
-          "dev": true
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5"
-          }
-        },
-        "inquirer": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-2.0.0.tgz",
-          "integrity": "sha1-4TUWh7kNFQykA86qPO+x4wZb70s=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "1.4.0",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.2.0",
-            "external-editor": "1.1.1",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
-            "mute-stream": "0.0.6",
-            "pinkie-promise": "2.0.1",
-            "run-async": "2.3.0",
-            "rx": "4.1.0",
-            "string-width": "2.1.1",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "1.1.0"
-          }
-        },
-        "ora": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-1.3.0.tgz",
-          "integrity": "sha1-gAeN0rkqk0r2ajrXKluRBpTt5Ro=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "cli-cursor": "2.1.0",
-            "cli-spinners": "1.1.0",
-            "log-symbols": "1.0.2"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "cli-cursor": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-              "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-              "dev": true,
-              "requires": {
-                "restore-cursor": "2.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "run-async": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-          "dev": true,
-          "requires": {
-            "is-promise": "2.1.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
-      }
     },
     "consolidate": {
       "version": "0.14.5",
@@ -2830,6 +2633,15 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
+    },
     "dag-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-2.0.2.tgz",
@@ -2848,14 +2660,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "1.0.0"
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2913,15 +2733,6 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
-    "detect-file": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true,
-      "requires": {
-        "fs-exists-sync": "0.1.0"
-      }
-    },
     "diff": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
@@ -2955,6 +2766,12 @@
         "is-obj": "1.0.1"
       }
     },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
     "editions": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
@@ -2972,9 +2789,9 @@
       "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0="
     },
     "ember-cli": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.18.2.tgz",
-      "integrity": "sha1-uxUxOhUTmoUkiobSA2Q/kYukD1c=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.0.0.tgz",
+      "integrity": "sha512-J17+IwqJgYN++buwCA0G9pBE1AWWBGgz5NR917F+grNVkY0548KRwa/AkGklpWTpXda3EpT0ytBofJWN3Soldw==",
       "dev": true,
       "requires": {
         "amd-name-resolver": "1.0.0",
@@ -2982,7 +2799,6 @@
         "bower-config": "1.4.1",
         "bower-endpoint-parser": "0.2.2",
         "broccoli-babel-transpiler": "6.1.2",
-        "broccoli-brocfile-loader": "0.18.0",
         "broccoli-builder": "0.18.10",
         "broccoli-concat": "3.2.2",
         "broccoli-config-loader": "1.0.1",
@@ -2996,22 +2812,20 @@
         "broccoli-stew": "1.5.0",
         "calculate-cache-key-for-tree": "1.1.0",
         "capture-exit": "1.2.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "clean-base-url": "1.0.0",
         "compression": "1.7.1",
         "configstore": "3.1.1",
-        "console-ui": "2.0.1",
+        "console-ui": "2.1.0",
         "core-object": "3.1.5",
         "dag-map": "2.0.2",
         "diff": "3.4.0",
         "ember-cli-broccoli-sane-watcher": "2.0.4",
         "ember-cli-is-package-missing": "1.0.0",
-        "ember-cli-legacy-blueprints": "0.2.1",
         "ember-cli-lodash-subset": "2.0.1",
         "ember-cli-normalize-entity-name": "1.0.0",
         "ember-cli-preprocess-registry": "3.1.1",
         "ember-cli-string-utils": "1.1.0",
-        "ember-try": "0.2.22",
         "ensure-posix-path": "1.0.2",
         "execa": "0.8.0",
         "exists-sync": "0.0.4",
@@ -3048,7 +2862,7 @@
         "quick-temp": "0.1.8",
         "resolve": "1.5.0",
         "rsvp": "4.8.1",
-        "sane": "2.3.0",
+        "sane": "2.4.1",
         "semver": "5.4.1",
         "silent-error": "1.1.0",
         "sort-package-json": "1.7.1",
@@ -3060,6 +2874,7 @@
         "uuid": "3.1.0",
         "validate-npm-package-name": "3.0.0",
         "walk-sync": "0.3.2",
+        "watch-detector": "0.1.0",
         "yam": "0.0.22"
       },
       "dependencies": {
@@ -3072,6 +2887,12 @@
             "ensure-posix-path": "1.0.2"
           }
         },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -3080,12 +2901,6 @@
           "requires": {
             "color-convert": "1.9.1"
           }
-        },
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
         },
         "broccoli-funnel": {
           "version": "2.0.1",
@@ -3119,47 +2934,28 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
-        "ember-cli-legacy-blueprints": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-legacy-blueprints/-/ember-cli-legacy-blueprints-0.2.1.tgz",
-          "integrity": "sha1-SA83y4Px7aLUa7x9B8WeoujOm4Q=",
+        "console-ui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/console-ui/-/console-ui-2.1.0.tgz",
+          "integrity": "sha512-/FqFHRwYVjjdeLd/1lhRsyoPCMtDMREJfPU6WCN9LMxPWu3++Cr2wN1uIZfbefVwr59is4UBd6Z2vaJRzTyPWQ==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
-            "ember-cli-get-component-path-option": "1.0.0",
-            "ember-cli-get-dependency-depth": "1.0.0",
-            "ember-cli-is-package-missing": "1.0.0",
-            "ember-cli-lodash-subset": "2.0.1",
-            "ember-cli-normalize-entity-name": "1.0.0",
-            "ember-cli-path-utils": "1.0.0",
-            "ember-cli-string-utils": "1.1.0",
-            "ember-cli-test-info": "1.0.0",
-            "ember-cli-valid-component-name": "1.0.0",
-            "ember-cli-version-checker": "2.1.0",
-            "ember-router-generator": "1.2.3",
-            "exists-sync": "0.0.3",
-            "fs-extra": "4.0.3",
-            "inflection": "1.12.0",
-            "rsvp": "4.8.1",
-            "silent-error": "1.1.0"
-          },
-          "dependencies": {
-            "exists-sync": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
-              "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8=",
-              "dev": true
-            }
+            "chalk": "2.3.1",
+            "inquirer": "2.0.0",
+            "json-stable-stringify": "1.0.1",
+            "ora": "1.4.0",
+            "through": "2.3.8",
+            "user-info": "1.0.0"
           }
         },
         "ember-cli-lodash-subset": {
@@ -3167,16 +2963,6 @@
           "resolved": "https://registry.npmjs.org/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz",
           "integrity": "sha1-IMtop5D+D94kiN39jvu332/nZvI=",
           "dev": true
-        },
-        "ember-cli-version-checker": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
-          "dev": true,
-          "requires": {
-            "resolve": "1.5.0",
-            "semver": "5.4.1"
-          }
         },
         "fs-extra": {
           "version": "4.0.3",
@@ -3203,6 +2989,67 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-2.0.0.tgz",
+          "integrity": "sha1-4TUWh7kNFQykA86qPO+x4wZb70s=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.2.0",
+            "external-editor": "1.1.1",
+            "figures": "2.0.0",
+            "lodash": "4.17.5",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "2.0.1",
+            "run-async": "2.3.0",
+            "rx": "4.1.0",
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -3211,6 +3058,12 @@
           "requires": {
             "graceful-fs": "4.1.11"
           }
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
         },
         "lodash._reinterpolate": {
           "version": "3.0.0",
@@ -3246,17 +3099,11 @@
             "brace-expansion": "1.1.8"
           }
         },
-        "npm-package-arg": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.0.0.tgz",
-          "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "osenv": "0.1.4",
-            "semver": "5.4.1",
-            "validate-npm-package-name": "3.0.0"
-          }
+        "mute-stream": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
+          "dev": true
         },
         "rsvp": {
           "version": "4.8.1",
@@ -3265,9 +3112,9 @@
           "dev": true
         },
         "sane": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/sane/-/sane-2.3.0.tgz",
-          "integrity": "sha512-6GB9zPCsqJqQPAGcvEkUPijM1ZUFI+A/DrscL++dXO3Ltt5q5mPDayGxZtr3cBRkrbb4akbwszVVkTIFefEkcg==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-2.4.1.tgz",
+          "integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
           "dev": true,
           "requires": {
             "anymatch": "1.3.2",
@@ -3280,65 +3127,34 @@
             "watch": "0.18.0"
           }
         },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "testem": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/testem/-/testem-2.0.0.tgz",
-          "integrity": "sha1-sFyWIAx6yYuumY1xyUwMU0WQfRM=",
-          "dev": true,
-          "requires": {
-            "backbone": "1.3.3",
-            "bluebird": "3.5.1",
-            "charm": "1.0.2",
-            "commander": "2.12.1",
-            "consolidate": "0.14.5",
-            "execa": "0.9.0",
-            "express": "4.16.2",
-            "fireworm": "0.7.1",
-            "glob": "7.1.1",
-            "http-proxy": "1.16.2",
-            "js-yaml": "3.10.0",
-            "lodash.assignin": "4.2.0",
-            "lodash.castarray": "4.4.0",
-            "lodash.clonedeep": "4.5.0",
-            "lodash.find": "4.6.0",
-            "lodash.uniqby": "4.7.0",
-            "mkdirp": "0.5.1",
-            "mustache": "2.3.0",
-            "node-notifier": "5.1.2",
-            "npmlog": "4.1.2",
-            "printf": "0.2.5",
-            "rimraf": "2.6.2",
-            "socket.io": "1.6.0",
-            "spawn-args": "0.2.0",
-            "styled_string": "0.0.1",
-            "tap-parser": "5.4.0",
-            "xmldom": "0.1.27"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
-            "execa": {
-              "version": "0.9.0",
-              "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
-              "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
+          }
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
           }
         },
         "watch": {
@@ -3454,12 +3270,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz",
       "integrity": "sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=",
-      "dev": true
-    },
-    "ember-cli-get-dependency-depth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-get-dependency-depth/-/ember-cli-get-dependency-depth-1.0.0.tgz",
-      "integrity": "sha1-4K/s+CotUvAPKKtGgpUoGuw2jRE=",
       "dev": true
     },
     "ember-cli-htmlbars": {
@@ -3616,15 +3426,6 @@
       "integrity": "sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=",
       "dev": true
     },
-    "ember-cli-test-info": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-test-info/-/ember-cli-test-info-1.0.0.tgz",
-      "integrity": "sha1-7U6WDySel1I8+JHkrtIHLOhFd7Q=",
-      "dev": true,
-      "requires": {
-        "ember-cli-string-utils": "1.1.0"
-      }
-    },
     "ember-cli-test-loader": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz",
@@ -3653,6 +3454,16 @@
         "silent-error": "1.1.0"
       }
     },
+    "ember-cli-version-checker": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+      "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+      "dev": true,
+      "requires": {
+        "resolve": "1.5.0",
+        "semver": "5.4.1"
+      }
+    },
     "ember-disable-prototype-extensions": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz",
@@ -3677,14 +3488,24 @@
         "ember-cli-babel": "6.10.0"
       }
     },
-    "ember-native-dom-helpers": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.10.tgz",
-      "integrity": "sha512-bPJX49vlgnBGwFn/3WJPPJjjyd7/atvzW5j01u1dbyFf3bXvHg9Rs1qaZJdk8js0qZ1FINadIEC9vWtgN3w7tg==",
+    "ember-maybe-import-regenerator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz",
+      "integrity": "sha1-NdQYKK+m1qWbwNo85H80xXPXdso=",
       "dev": true,
       "requires": {
         "broccoli-funnel": "1.2.0",
-        "ember-cli-babel": "6.10.0"
+        "broccoli-merge-trees": "1.2.4",
+        "ember-cli-babel": "6.10.0",
+        "regenerator-runtime": "0.9.6"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+          "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
+          "dev": true
+        }
       }
     },
     "ember-qunit": {
@@ -3816,9 +3637,9 @@
       }
     },
     "ember-source": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.18.0.tgz",
-      "integrity": "sha1-9hzycB2KqUpq3ubUex1ac6TO9fY=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.0.0.tgz",
+      "integrity": "sha1-UYEcrpjSzuxTvPuqh20CsrWyFZ8=",
       "dev": true,
       "requires": {
         "broccoli-funnel": "2.0.1",
@@ -3828,7 +3649,6 @@
         "ember-cli-normalize-entity-name": "1.0.0",
         "ember-cli-path-utils": "1.0.0",
         "ember-cli-string-utils": "1.1.0",
-        "ember-cli-test-info": "1.0.0",
         "ember-cli-valid-component-name": "1.0.0",
         "ember-cli-version-checker": "2.1.0",
         "ember-router-generator": "1.2.3",
@@ -3868,16 +3688,6 @@
             "merge-trees": "1.0.1"
           }
         },
-        "ember-cli-version-checker": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
-          "dev": true,
-          "requires": {
-            "resolve": "1.5.0",
-            "semver": "5.4.1"
-          }
-        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -3889,65 +3699,13 @@
         }
       }
     },
-    "ember-try": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.22.tgz",
-      "integrity": "sha512-5NKqlKCGWqTUWAA61/dchIFKG2loqEBcHHI4ZbCHToKdK82NTzWkifxryhmwzFE0c9MomvQ3Rza7yxVD5C9rMw==",
+    "ember-source-channel-url": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-source-channel-url/-/ember-source-channel-url-1.0.1.tgz",
+      "integrity": "sha512-IRorqDEVyG1D01bzKuQgR0E9+cf2OsUboq4dg6eTQRBkZ/DnMK8Q8YuqODdQbozBSZAunvWFce3XJBCkdM1Bjg==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-table2": "0.2.0",
-        "core-object": "1.1.0",
-        "debug": "2.6.9",
-        "ember-try-config": "2.2.0",
-        "extend": "3.0.1",
-        "fs-extra": "0.26.7",
-        "promise-map-series": "0.2.3",
-        "resolve": "1.5.0",
-        "rimraf": "2.6.2",
-        "rsvp": "3.6.2",
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "core-object": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/core-object/-/core-object-1.1.0.tgz",
-          "integrity": "sha1-htY5GHM8+doaWq5ynmLAqI5mrQo=",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "0.26.7",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-          "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
-          }
-        }
-      }
-    },
-    "ember-try-config": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-try-config/-/ember-try-config-2.2.0.tgz",
-      "integrity": "sha1-a+CvbHGUmBPgKseTVk/dv4M2uAc=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4",
-        "node-fetch": "1.7.3",
-        "rsvp": "3.6.2",
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
+        "got": "8.1.0"
       }
     },
     "encodeurl": {
@@ -3955,15 +3713,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
     },
     "engine.io": {
       "version": "1.8.0",
@@ -4093,6 +3842,15 @@
       "requires": {
         "string-template": "0.2.1",
         "xtend": "4.0.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
       }
     },
     "escape-html": {
@@ -4357,6 +4115,17 @@
       "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
       "dev": true
     },
+    "exec-file-sync": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/exec-file-sync/-/exec-file-sync-2.0.2.tgz",
+      "integrity": "sha1-WNRB20bkDebR8w3lvgInhb2J4yg=",
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1",
+        "object-assign": "4.1.1",
+        "spawn-sync": "1.0.15"
+      }
+    },
     "exec-sh": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
@@ -4420,15 +4189,6 @@
       "dev": true,
       "requires": {
         "fill-range": "2.2.3"
-      }
-    },
-    "expand-tilde": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
       }
     },
     "express": {
@@ -5071,11 +4831,53 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-      "dev": true
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+          "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
     },
     "fs-extra": {
       "version": "0.30.0",
@@ -6207,28 +6009,6 @@
         "is-glob": "2.0.1"
       }
     },
-    "global-modules": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "dev": true,
-      "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
-      }
-    },
-    "global-prefix": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "dev": true,
-      "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "0.2.0",
-        "which": "1.3.0"
-      }
-    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -6278,6 +6058,31 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
+      }
+    },
+    "got": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.1.0.tgz",
+      "integrity": "sha512-clILMRaLB1Ase3NWiSgTUrhpc951Z5V2IMtcFp8SKwu2aY+aeZZUuv/KKQmix+pz+Ov9SugLry6+JsBezHa9Vw==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "0.7.0",
+        "cacheable-request": "2.1.4",
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "into-stream": "3.1.0",
+        "is-retry-allowed": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.0",
+        "mimic-response": "1.0.0",
+        "p-cancelable": "0.3.0",
+        "p-timeout": "2.0.1",
+        "pify": "3.0.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "3.0.0",
+        "url-to-options": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -6355,6 +6160,21 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
+      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA==",
+      "dev": true
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "1.4.1"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -6488,6 +6308,12 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "dev": true
+    },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
@@ -6541,6 +6367,15 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "indexof": {
       "version": "0.0.1",
@@ -6731,6 +6566,16 @@
         }
       }
     },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "dev": true,
+      "requires": {
+        "from2": "2.3.0",
+        "p-is-promise": "1.1.0"
+      }
+    },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
@@ -6762,6 +6607,12 @@
         }
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -6776,6 +6627,15 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-data-descriptor": {
       "version": "1.0.0",
@@ -6887,6 +6747,12 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-odd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
@@ -6930,6 +6796,12 @@
       "requires": {
         "path-is-inside": "1.0.2"
       }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -6975,6 +6847,12 @@
         "tryit": "1.0.3"
       }
     },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -6990,10 +6868,10 @@
         "core-util-is": "1.0.2"
       }
     },
-    "is-windows": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "isarray": {
@@ -7041,6 +6919,16 @@
         "textextensions": "2.1.0"
       }
     },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "dev": true,
+      "requires": {
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
+      }
+    },
     "jquery": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
@@ -7075,6 +6963,12 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -7120,6 +7014,15 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -7182,6 +7085,36 @@
       "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
       "dev": true
     },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
+      }
+    },
     "loader.js": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/loader.js/-/loader.js-4.6.0.tgz",
@@ -7205,12 +7138,6 @@
           "dev": true
         }
       }
-    },
-    "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-      "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -7660,15 +7587,6 @@
         "lodash.keys": "2.3.0"
       }
     },
-    "log-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3"
-      }
-    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -7690,10 +7608,26 @@
         }
       }
     },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
+    },
     "lower-case": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true
     },
     "lru-cache": {
@@ -7728,6 +7662,12 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "map-visit": {
@@ -7830,6 +7770,24 @@
         "readable-stream": "1.0.34"
       }
     },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      }
+    },
     "merge": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
@@ -7908,6 +7866,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
       "dev": true
     },
     "minimatch": {
@@ -8068,16 +8032,6 @@
         "lower-case": "1.1.4"
       }
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8111,6 +8065,18 @@
         "abbrev": "1.1.1"
       }
     },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
+      }
+    },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -8118,6 +8084,29 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "dev": true,
+      "requires": {
+        "prepend-http": "2.0.0",
+        "query-string": "5.1.0",
+        "sort-keys": "2.0.0"
+      }
+    },
+    "npm-package-arg": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.0.0.tgz",
+      "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "osenv": "0.1.4",
+        "semver": "5.4.1",
+        "validate-npm-package-name": "3.0.0"
       }
     },
     "npm-run-path": {
@@ -8335,6 +8324,92 @@
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
       "dev": true
     },
+    "ora": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
+      "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.1",
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "1.1.0",
+        "log-symbols": "2.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.2.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -8361,10 +8436,22 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "p-cancelable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
     "p-limit": {
@@ -8382,6 +8469,15 @@
         "p-limit": "1.1.0"
       }
     },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "dev": true,
+      "requires": {
+        "p-finally": "1.0.0"
+      }
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -8392,6 +8488,15 @@
         "is-dotfile": "1.0.3",
         "is-extglob": "1.0.0",
         "is-glob": "2.0.1"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
       }
     },
     "parse-passwd": {
@@ -8439,6 +8544,24 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "passwd-user": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/passwd-user/-/passwd-user-1.2.1.tgz",
+      "integrity": "sha1-oBpdxjnvAH3FY2S4F4VpCArTp7g=",
+      "dev": true,
+      "requires": {
+        "exec-file-sync": "2.0.2"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -8471,6 +8594,25 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
     },
     "pify": {
       "version": "3.0.0",
@@ -8528,6 +8670,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
     "preserve": {
@@ -8597,6 +8745,17 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
+    },
+    "query-string": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.0.tgz",
+      "integrity": "sha512-F3DkxxlY0AqD/rwe4YAwjRE2HjOkKW7TxsuteyrS/Jbwrxw887PqYBL4sWUJ9D/V1hmFns0SCD6FDyvlwo9RCQ==",
+      "dev": true,
+      "requires": {
+        "decode-uri-component": "0.2.0",
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
     },
     "quick-temp": {
       "version": "0.1.8",
@@ -8691,6 +8850,39 @@
         "unpipe": "1.0.0"
       }
     },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        }
+      }
+    },
     "readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -8754,6 +8946,16 @@
             "safe-buffer": "5.1.1"
           }
         }
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "redeyed": {
@@ -8844,6 +9046,15 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
     "require-folder-tree": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/require-folder-tree/-/require-folder-tree-1.4.5.tgz",
@@ -8885,16 +9096,6 @@
         "path-parse": "1.0.5"
       }
     },
-    "resolve-dir": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "dev": true,
-      "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
-      }
-    },
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
@@ -8906,6 +9107,15 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "1.0.0"
+      }
     },
     "restore-cursor": {
       "version": "1.0.1",
@@ -9437,6 +9647,15 @@
         }
       }
     },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
     "sort-object-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.2.tgz",
@@ -9528,6 +9747,27 @@
         "concat-stream": "1.6.0",
         "os-shim": "0.1.3"
       }
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
     },
     "split-string": {
       "version": "3.1.0",
@@ -9654,6 +9894,12 @@
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
     "string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -9696,6 +9942,15 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -9874,6 +10129,81 @@
         }
       }
     },
+    "testem": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/testem/-/testem-2.0.0.tgz",
+      "integrity": "sha1-sFyWIAx6yYuumY1xyUwMU0WQfRM=",
+      "dev": true,
+      "requires": {
+        "backbone": "1.3.3",
+        "bluebird": "3.5.1",
+        "charm": "1.0.2",
+        "commander": "2.12.1",
+        "consolidate": "0.14.5",
+        "execa": "0.9.0",
+        "express": "4.16.2",
+        "fireworm": "0.7.1",
+        "glob": "7.1.2",
+        "http-proxy": "1.16.2",
+        "js-yaml": "3.10.0",
+        "lodash.assignin": "4.2.0",
+        "lodash.castarray": "4.4.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.find": "4.6.0",
+        "lodash.uniqby": "4.7.0",
+        "mkdirp": "0.5.1",
+        "mustache": "2.3.0",
+        "node-notifier": "5.1.2",
+        "npmlog": "4.1.2",
+        "printf": "0.2.5",
+        "rimraf": "2.6.2",
+        "socket.io": "1.6.0",
+        "spawn-args": "0.2.0",
+        "styled_string": "0.0.1",
+        "tap-parser": "5.4.0",
+        "xmldom": "0.1.27"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9889,6 +10219,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
     "tiny-lr": {
@@ -10061,6 +10397,12 @@
           }
         }
       }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
@@ -10280,6 +10622,21 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "2.0.0"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true
+    },
     "use": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
@@ -10374,6 +10731,26 @@
         }
       }
     },
+    "user-info": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/user-info/-/user-info-1.0.0.tgz",
+      "integrity": "sha1-gcgrftY+Z0wkdWZ2U0E7PHb94jk=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "passwd-user": "1.2.1",
+        "username": "1.0.1"
+      }
+    },
+    "username": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/username/-/username-1.0.1.tgz",
+      "integrity": "sha1-4fcilePljgbwAsYyfOBol6mc1n8=",
+      "dev": true,
+      "requires": {
+        "meow": "3.7.0"
+      }
+    },
     "username-sync": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/username-sync/-/username-sync-1.0.1.tgz",
@@ -10395,6 +10772,16 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
@@ -10434,6 +10821,27 @@
       "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
       "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
       "dev": true
+    },
+    "watch-detector": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/watch-detector/-/watch-detector-0.1.0.tgz",
+      "integrity": "sha512-vfzMMfpjQc88xjETwl2HuE6PjEuxCBeyC4bQmqrHrofdfYWi/4mEJklYbNgSzpqM9PxubsiPIrE5SZ1FDyiQ2w==",
+      "dev": true,
+      "requires": {
+        "heimdalljs-logger": "0.1.9",
+        "quick-temp": "0.1.8",
+        "rsvp": "4.8.1",
+        "semver": "5.4.1",
+        "silent-error": "1.1.0"
+      },
+      "dependencies": {
+        "rsvp": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.1.tgz",
+          "integrity": "sha512-c9tShmZbQ5nLVVVl3Fuhk1NExJlXfAMIEz7a8GC570X8XhNQNZPFAdjOeMmJEN3SLYOOb2OprS576P/QO4QouA==",
+          "dev": true
+        }
+      }
     },
     "websocket-driver": {
       "version": "0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,14 @@
   "requires": true,
   "dependencies": {
     "@ember/test-helpers": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-0.7.1.tgz",
-      "integrity": "sha512-NYRXO6Kn/d+86V4PtTUEQZzOAZIR4Okck/mWCW3XtjN9zYi+Zuwn7l6lhq8Z3QKEfi4NrDW+v+mJv4jvmx/agA==",
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-0.7.16.tgz",
+      "integrity": "sha512-4hECIjZUOf82d13I1eueUeR+Kp/A1t4nfX7K/GebMuShmFUM46h8cNp33aXML+UGCGiC8TkNNML8Rb8vTObk5Q==",
       "dev": true,
       "requires": {
         "broccoli-funnel": "2.0.1",
-        "ember-cli-babel": "6.10.0"
+        "ember-cli-babel": "6.10.0",
+        "ember-cli-htmlbars-inline-precompile": "1.0.2"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -133,15 +134,6 @@
         "kind-of": "3.2.2",
         "longest": "1.0.1",
         "repeat-string": "1.6.1"
-      }
-    },
-    "alter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
-      "dev": true,
-      "requires": {
-        "stable": "0.1.6"
       }
     },
     "amd-name-resolver": {
@@ -287,6 +279,12 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
@@ -346,10 +344,10 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "ast-traverse": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
-      "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
     "ast-types": {
@@ -401,6 +399,12 @@
         "async": "2.6.0",
         "debug": "2.6.9"
       }
+    },
+    "atob": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -658,18 +662,6 @@
         "babel-runtime": "6.26.0"
       }
     },
-    "babel-plugin-constant-folding": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
-      "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4=",
-      "dev": true
-    },
-    "babel-plugin-dead-code-elimination": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
-      "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U=",
-      "dev": true
-    },
     "babel-plugin-debug-macros": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz",
@@ -686,79 +678,10 @@
         "ember-rfc176-data": "0.3.1"
       }
     },
-    "babel-plugin-eval": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
-      "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo=",
-      "dev": true
-    },
     "babel-plugin-htmlbars-inline-precompile": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.3.tgz",
       "integrity": "sha1-zTZeJ4r0Cb+mvncExDVL7udCRGs=",
-      "dev": true
-    },
-    "babel-plugin-inline-environment-variables": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
-      "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4=",
-      "dev": true
-    },
-    "babel-plugin-jscript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
-      "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w=",
-      "dev": true
-    },
-    "babel-plugin-member-expression-literals": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
-      "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM=",
-      "dev": true
-    },
-    "babel-plugin-property-literals": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
-      "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY=",
-      "dev": true
-    },
-    "babel-plugin-proto-to-assign": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
-      "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
-      "dev": true,
-      "requires": {
-        "lodash": "3.10.1"
-      }
-    },
-    "babel-plugin-react-constant-elements": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
-      "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o=",
-      "dev": true
-    },
-    "babel-plugin-react-display-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
-      "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw=",
-      "dev": true
-    },
-    "babel-plugin-remove-console": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
-      "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c=",
-      "dev": true
-    },
-    "babel-plugin-remove-debugger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
-      "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc=",
-      "dev": true
-    },
-    "babel-plugin-runtime": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
-      "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
       "dev": true
     },
     "babel-plugin-syntax-async-functions": {
@@ -1032,21 +955,6 @@
         "babel-types": "6.26.0"
       }
     },
-    "babel-plugin-undeclared-variables-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-      "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
-      "dev": true,
-      "requires": {
-        "leven": "1.0.2"
-      }
-    },
-    "babel-plugin-undefined-to-void": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
-      "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
-      "dev": true
-    },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -1304,6 +1212,35 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.0",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
@@ -1354,12 +1291,6 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
-      "dev": true
-    },
-    "bluebird": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
       "dev": true
     },
     "body": {
@@ -1448,12 +1379,6 @@
         "preserve": "0.2.0",
         "repeat-element": "1.1.2"
       }
-    },
-    "breakable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
-      "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
-      "dev": true
     },
     "broccoli-asset-rev": {
       "version": "2.6.0",
@@ -2022,6 +1947,37 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "calculate-cache-key-for-tree": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.1.0.tgz",
@@ -2056,7 +2012,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "can-symlink": {
       "version": "1.0.0",
@@ -2095,6 +2052,7 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
+      "optional": true,
       "requires": {
         "align-text": "0.1.4",
         "lazy-cache": "1.0.4"
@@ -2128,9 +2086,9 @@
       }
     },
     "chokidar": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
-      "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
         "anymatch": "1.3.2",
@@ -2149,6 +2107,92 @@
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
     },
     "clean-base-url": {
       "version": "1.0.0",
@@ -2245,6 +2289,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "center-align": "0.1.3",
         "right-align": "0.1.3",
@@ -2267,6 +2312,16 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
     },
     "color-convert": {
       "version": "1.9.1",
@@ -2297,49 +2352,12 @@
       "dev": true
     },
     "common-tags": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.5.1.tgz",
-      "integrity": "sha512-NrUYGY5TApAk9KB+IZXkR3GR4tA3g26HDsoiGt4kCMHZ727gOGkC+UNfq0Z22jE15bLkc/6RV5Jw1RBW6Usg6A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
+      "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
-      }
-    },
-    "commoner": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-      "dev": true,
-      "requires": {
-        "commander": "2.12.1",
-        "detective": "4.5.0",
-        "glob": "5.0.15",
-        "graceful-fs": "4.1.11",
-        "iconv-lite": "0.4.19",
-        "mkdirp": "0.5.1",
-        "private": "0.1.8",
-        "q": "1.5.1",
-        "recast": "0.11.23"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
-        "recast": {
-          "version": "0.11.23",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-          "dev": true,
-          "requires": {
-            "ast-types": "0.9.6",
-            "esprima": "3.1.3",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
-          }
-        }
       }
     },
     "component-bind": {
@@ -2738,6 +2756,12 @@
       "integrity": "sha1-axMYZUIP2BtBO6mUtE02VTERUrY=",
       "dev": true
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
@@ -2824,6 +2848,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "deep-is": {
@@ -2832,36 +2863,13 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "defined": {
+    "define-property": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
-    },
-    "defs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-      "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "requires": {
-        "alter": "0.2.0",
-        "ast-traverse": "0.1.1",
-        "breakable": "1.0.0",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "simple-fmt": "0.1.0",
-        "simple-is": "0.2.0",
-        "stringmap": "0.2.2",
-        "stringset": "0.2.1",
-        "tryor": "0.1.2",
-        "yargs": "3.27.0"
-      },
-      "dependencies": {
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-          "dev": true
-        }
+        "is-descriptor": "1.0.2"
       }
     },
     "del": {
@@ -2914,35 +2922,6 @@
         "fs-exists-sync": "0.1.0"
       }
     },
-    "detect-indent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-      "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "4.0.1",
-        "minimist": "1.2.0",
-        "repeating": "1.1.3"
-      }
-    },
-    "detective": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
-      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
-      "dev": true,
-      "requires": {
-        "acorn": "4.0.13",
-        "defined": "1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
-    },
     "diff": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
@@ -2993,9 +2972,9 @@
       "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0="
     },
     "ember-cli": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.17.0.tgz",
-      "integrity": "sha1-T4sYkHJOVOeAJC/00FtJjjZ+NGE=",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.18.2.tgz",
+      "integrity": "sha1-uxUxOhUTmoUkiobSA2Q/kYukD1c=",
       "dev": true,
       "requires": {
         "amd-name-resolver": "1.0.0",
@@ -3027,7 +3006,7 @@
         "diff": "3.4.0",
         "ember-cli-broccoli-sane-watcher": "2.0.4",
         "ember-cli-is-package-missing": "1.0.0",
-        "ember-cli-legacy-blueprints": "0.1.5",
+        "ember-cli-legacy-blueprints": "0.2.1",
         "ember-cli-lodash-subset": "2.0.1",
         "ember-cli-normalize-entity-name": "1.0.0",
         "ember-cli-preprocess-registry": "3.1.1",
@@ -3063,19 +3042,19 @@
         "morgan": "1.9.0",
         "node-modules-path": "1.0.1",
         "nopt": "3.0.6",
-        "npm-package-arg": "4.2.1",
+        "npm-package-arg": "6.0.0",
         "portfinder": "1.0.13",
         "promise-map-series": "0.2.3",
         "quick-temp": "0.1.8",
         "resolve": "1.5.0",
-        "rsvp": "4.7.0",
-        "sane": "1.7.0",
+        "rsvp": "4.8.1",
+        "sane": "2.3.0",
         "semver": "5.4.1",
         "silent-error": "1.1.0",
         "sort-package-json": "1.7.1",
         "symlink-or-copy": "1.1.8",
         "temp": "0.8.3",
-        "testem": "1.18.4",
+        "testem": "2.0.0",
         "tiny-lr": "1.0.5",
         "tree-sync": "1.2.2",
         "uuid": "3.1.0",
@@ -3101,6 +3080,12 @@
           "requires": {
             "color-convert": "1.9.1"
           }
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
         },
         "broccoli-funnel": {
           "version": "2.0.1",
@@ -3144,11 +3129,54 @@
             "supports-color": "4.5.0"
           }
         },
+        "ember-cli-legacy-blueprints": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-legacy-blueprints/-/ember-cli-legacy-blueprints-0.2.1.tgz",
+          "integrity": "sha1-SA83y4Px7aLUa7x9B8WeoujOm4Q=",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "ember-cli-get-component-path-option": "1.0.0",
+            "ember-cli-get-dependency-depth": "1.0.0",
+            "ember-cli-is-package-missing": "1.0.0",
+            "ember-cli-lodash-subset": "2.0.1",
+            "ember-cli-normalize-entity-name": "1.0.0",
+            "ember-cli-path-utils": "1.0.0",
+            "ember-cli-string-utils": "1.1.0",
+            "ember-cli-test-info": "1.0.0",
+            "ember-cli-valid-component-name": "1.0.0",
+            "ember-cli-version-checker": "2.1.0",
+            "ember-router-generator": "1.2.3",
+            "exists-sync": "0.0.3",
+            "fs-extra": "4.0.3",
+            "inflection": "1.12.0",
+            "rsvp": "4.8.1",
+            "silent-error": "1.1.0"
+          },
+          "dependencies": {
+            "exists-sync": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
+              "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8=",
+              "dev": true
+            }
+          }
+        },
         "ember-cli-lodash-subset": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz",
           "integrity": "sha1-IMtop5D+D94kiN39jvu332/nZvI=",
           "dev": true
+        },
+        "ember-cli-version-checker": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "dev": true,
+          "requires": {
+            "resolve": "1.5.0",
+            "semver": "5.4.1"
+          }
         },
         "fs-extra": {
           "version": "4.0.3",
@@ -3218,11 +3246,39 @@
             "brace-expansion": "1.1.8"
           }
         },
+        "npm-package-arg": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.0.0.tgz",
+          "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "osenv": "0.1.4",
+            "semver": "5.4.1",
+            "validate-npm-package-name": "3.0.0"
+          }
+        },
         "rsvp": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.7.0.tgz",
-          "integrity": "sha1-3BsLGlNvfeydK+ReChKtQZfJ/ZY=",
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.1.tgz",
+          "integrity": "sha512-c9tShmZbQ5nLVVVl3Fuhk1NExJlXfAMIEz7a8GC570X8XhNQNZPFAdjOeMmJEN3SLYOOb2OprS576P/QO4QouA==",
           "dev": true
+        },
+        "sane": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-2.3.0.tgz",
+          "integrity": "sha512-6GB9zPCsqJqQPAGcvEkUPijM1ZUFI+A/DrscL++dXO3Ltt5q5mPDayGxZtr3cBRkrbb4akbwszVVkTIFefEkcg==",
+          "dev": true,
+          "requires": {
+            "anymatch": "1.3.2",
+            "exec-sh": "0.2.1",
+            "fb-watchman": "2.0.0",
+            "fsevents": "1.1.3",
+            "minimatch": "3.0.4",
+            "minimist": "1.2.0",
+            "walker": "1.0.7",
+            "watch": "0.18.0"
+          }
         },
         "supports-color": {
           "version": "4.5.0",
@@ -3231,6 +3287,68 @@
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
+          }
+        },
+        "testem": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/testem/-/testem-2.0.0.tgz",
+          "integrity": "sha1-sFyWIAx6yYuumY1xyUwMU0WQfRM=",
+          "dev": true,
+          "requires": {
+            "backbone": "1.3.3",
+            "bluebird": "3.5.1",
+            "charm": "1.0.2",
+            "commander": "2.12.1",
+            "consolidate": "0.14.5",
+            "execa": "0.9.0",
+            "express": "4.16.2",
+            "fireworm": "0.7.1",
+            "glob": "7.1.1",
+            "http-proxy": "1.16.2",
+            "js-yaml": "3.10.0",
+            "lodash.assignin": "4.2.0",
+            "lodash.castarray": "4.4.0",
+            "lodash.clonedeep": "4.5.0",
+            "lodash.find": "4.6.0",
+            "lodash.uniqby": "4.7.0",
+            "mkdirp": "0.5.1",
+            "mustache": "2.3.0",
+            "node-notifier": "5.1.2",
+            "npmlog": "4.1.2",
+            "printf": "0.2.5",
+            "rimraf": "2.6.2",
+            "socket.io": "1.6.0",
+            "spawn-args": "0.2.0",
+            "styled_string": "0.0.1",
+            "tap-parser": "5.4.0",
+            "xmldom": "0.1.27"
+          },
+          "dependencies": {
+            "execa": {
+              "version": "0.9.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+              "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+              "dev": true,
+              "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+              }
+            }
+          }
+        },
+        "watch": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+          "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+          "dev": true,
+          "requires": {
+            "exec-sh": "0.2.1",
+            "minimist": "1.2.0"
           }
         }
       }
@@ -3393,51 +3511,6 @@
       "integrity": "sha1-bmGEyvuSY13ZPKbJRrEEKS1OM5A=",
       "dev": true
     },
-    "ember-cli-legacy-blueprints": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/ember-cli-legacy-blueprints/-/ember-cli-legacy-blueprints-0.1.5.tgz",
-      "integrity": "sha1-k8FcokLsUQfWKor37DD2rFOPOtk=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "ember-cli-get-component-path-option": "1.0.0",
-        "ember-cli-get-dependency-depth": "1.0.0",
-        "ember-cli-is-package-missing": "1.0.0",
-        "ember-cli-lodash-subset": "1.0.12",
-        "ember-cli-normalize-entity-name": "1.0.0",
-        "ember-cli-path-utils": "1.0.0",
-        "ember-cli-string-utils": "1.1.0",
-        "ember-cli-test-info": "1.0.0",
-        "ember-cli-valid-component-name": "1.0.0",
-        "ember-cli-version-checker": "1.3.1",
-        "ember-router-generator": "1.2.3",
-        "exists-sync": "0.0.3",
-        "fs-extra": "0.24.0",
-        "inflection": "1.12.0",
-        "rsvp": "3.6.2",
-        "silent-error": "1.1.0"
-      },
-      "dependencies": {
-        "exists-sync": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
-          "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8=",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
-          "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
-          }
-        }
-      }
-    },
     "ember-cli-lodash-subset": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz",
@@ -3484,13 +3557,13 @@
       }
     },
     "ember-cli-qunit": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-qunit/-/ember-cli-qunit-4.1.1.tgz",
-      "integrity": "sha1-MHoVfp82oNMmIa4kfv+4kf+VH8c=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-qunit/-/ember-cli-qunit-4.3.0.tgz",
+      "integrity": "sha512-ClGZldPjHYIftEB80MPvdRdXhAo5QiJHzpO6nTsXC640hFoEtkvyRloKvHSnhR4UH31btMnA29ALAjpoRlufwA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "6.10.0",
-        "ember-qunit": "3.1.0"
+        "ember-qunit": "3.3.0"
       }
     },
     "ember-cli-shims": {
@@ -3552,6 +3625,15 @@
         "ember-cli-string-utils": "1.1.0"
       }
     },
+    "ember-cli-test-loader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz",
+      "integrity": "sha512-mlSXX9SciIRwGkFTX6XGyJYp4ry6oCFZRxh5jJ7VH8UXLTNx2ZACtDTwaWtNhYrWXgKyiDUvmD8enD56aePWRA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "6.10.0"
+      }
+    },
     "ember-cli-uglify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-uglify/-/ember-cli-uglify-2.0.0.tgz",
@@ -3571,15 +3653,6 @@
         "silent-error": "1.1.0"
       }
     },
-    "ember-cli-version-checker": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-      "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-      "dev": true,
-      "requires": {
-        "semver": "5.4.1"
-      }
-    },
     "ember-disable-prototype-extensions": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz",
@@ -3593,45 +3666,6 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "6.10.0"
-      }
-    },
-    "ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "requires": {
-        "ember-cli-version-checker": "2.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
-          "requires": {
-            "resolve": "1.5.0",
-            "semver": "5.4.1"
-          }
-        }
-      }
-    },
-    "ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "requires": {
-        "ember-cli-version-checker": "2.1.0",
-        "ember-factory-for-polyfill": "1.3.1"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
-          "requires": {
-            "resolve": "1.5.0",
-            "semver": "5.4.1"
-          }
-        }
       }
     },
     "ember-load-initializers": {
@@ -3654,18 +3688,18 @@
       }
     },
     "ember-qunit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-3.1.0.tgz",
-      "integrity": "sha512-hyqz1bX/83P9PgH16StlHGiNSFWMTCrGkt64wb4Qir+UGfilMYHN4zHBeYlTO+Sp/EqAk9fhTIyqOb9VtsbVtQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-3.3.0.tgz",
+      "integrity": "sha512-Vtiyj0yG0BOpYpjAH5/goS7pFzs3xeQ4QJzoikrtJ/OxB0EWYKyLCXc0Ha54yj+VSRI+fE+tBMPGj9oYAiSi5A==",
       "dev": true,
       "requires": {
-        "@ember/test-helpers": "0.7.1",
+        "@ember/test-helpers": "0.7.16",
         "broccoli-funnel": "2.0.1",
         "broccoli-merge-trees": "2.0.0",
-        "common-tags": "1.5.1",
+        "common-tags": "1.7.2",
         "ember-cli-babel": "6.10.0",
         "ember-cli-test-loader": "2.2.0",
-        "qunit": "2.4.1"
+        "qunit": "2.5.0"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -3697,15 +3731,6 @@
           "requires": {
             "broccoli-plugin": "1.3.0",
             "merge-trees": "1.0.1"
-          }
-        },
-        "ember-cli-test-loader": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz",
-          "integrity": "sha512-mlSXX9SciIRwGkFTX6XGyJYp4ry6oCFZRxh5jJ7VH8UXLTNx2ZACtDTwaWtNhYrWXgKyiDUvmD8enD56aePWRA==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "6.10.0"
           }
         },
         "minimatch": {
@@ -3791,12 +3816,12 @@
       }
     },
     "ember-source": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.17.0.tgz",
-      "integrity": "sha1-t4hx3Um9jWQrgBdt9Pr3/X0Fnaw=",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.18.0.tgz",
+      "integrity": "sha1-9hzycB2KqUpq3ubUex1ac6TO9fY=",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "1.2.0",
+        "broccoli-funnel": "2.0.1",
         "broccoli-merge-trees": "2.0.0",
         "ember-cli-get-component-path-option": "1.0.0",
         "ember-cli-is-package-missing": "1.0.0",
@@ -3807,12 +3832,32 @@
         "ember-cli-valid-component-name": "1.0.0",
         "ember-cli-version-checker": "2.1.0",
         "ember-router-generator": "1.2.3",
-        "fs-extra": "4.0.3",
         "inflection": "1.12.0",
         "jquery": "3.2.1",
         "resolve": "1.5.0"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.9",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.7",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.2",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
@@ -3833,24 +3878,13 @@
             "semver": "5.4.1"
           }
         },
-        "fs-extra": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -3912,134 +3946,6 @@
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
-      }
-    },
-    "ember-wait-for-test-helper": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ember-wait-for-test-helper/-/ember-wait-for-test-helper-0.1.1.tgz",
-      "integrity": "sha1-wzNHDJiaCXYtGIYRv6V1IG1lgRg=",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
-      "dependencies": {
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "1.5.1",
-            "core-js": "1.2.7",
-            "debug": "2.6.9",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "1.5.0",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "0.5.7",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
-        },
-        "babylon": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
-          "dev": true
-        },
-        "broccoli-babel-transpiler": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
-          "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "1.4.3",
-            "clone": "0.2.0",
-            "hash-for-dep": "1.2.3",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "2.3.0"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-              "dev": true
-            }
-          }
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        },
-        "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "5.7.2",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "1.3.1",
-            "resolve": "1.5.0"
-          }
-        },
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
           "dev": true
         }
       }
@@ -4329,6 +4235,54 @@
         }
       }
     },
+    "eslint-plugin-ember": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-5.0.3.tgz",
+      "integrity": "sha512-wPq2N96YQR2/Ob2LfuLQV8BEotHXxiFcuBiHikN8P+2VGzxBeuydafXy/pExuTsU2RHfPiSgyBHavKGy1DYdrQ==",
+      "dev": true,
+      "requires": {
+        "ember-rfc176-data": "0.2.7",
+        "require-folder-tree": "1.4.5",
+        "snake-case": "2.1.0"
+      },
+      "dependencies": {
+        "ember-rfc176-data": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz",
+          "integrity": "sha512-pJE2w+sI22UDsYmudI4nCp3WcImpUzXwe9qHfpOcEu3yM/HD1nGpDRt6kZD0KUnDmqkLeik/nYyzEwN/NU6xxA==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
+      "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
+      "dev": true,
+      "requires": {
+        "ignore": "3.3.7",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
+        "semver": "5.3.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
@@ -4537,6 +4491,15 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1"
+      }
     },
     "external-editor": {
       "version": "1.1.1",
@@ -4750,15 +4713,284 @@
       }
     },
     "findup-sync": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
-      "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "0.1.0",
-        "is-glob": "2.0.1",
-        "micromatch": "2.3.11",
-        "resolve-dir": "0.1.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.5",
+        "resolve-dir": "1.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
+          "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.1",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.1"
+          }
+        },
+        "detect-file": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+          "dev": true
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            }
+          }
+        },
+        "expand-tilde": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "1.0.1"
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          }
+        },
+        "global-modules": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "dev": true,
+          "requires": {
+            "global-prefix": "1.0.2",
+            "is-windows": "1.0.1",
+            "resolve-dir": "1.0.1"
+          }
+        },
+        "global-prefix": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+          "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+          "dev": true,
+          "requires": {
+            "expand-tilde": "2.0.2",
+            "homedir-polyfill": "1.0.1",
+            "ini": "1.3.5",
+            "is-windows": "1.0.1",
+            "which": "1.3.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-windows": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+          "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
+          "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.0",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.7",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.0",
+            "snapdragon": "0.8.1",
+            "to-regex": "3.0.1"
+          }
+        },
+        "resolve-dir": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+          "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+          "dev": true,
+          "requires": {
+            "expand-tilde": "2.0.2",
+            "global-modules": "1.0.0"
+          }
+        }
       }
     },
     "fireworm": {
@@ -4824,6 +5056,15 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -4848,12 +5089,6 @@
         "path-is-absolute": "1.0.1",
         "rimraf": "2.6.2"
       }
-    },
-    "fs-readdir-recursive": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
-      "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=",
-      "dev": true
     },
     "fs-tree-diff": {
       "version": "0.5.7",
@@ -4884,13 +5119,15 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4900,18 +5137,21 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4921,42 +5161,49 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4965,7 +5212,8 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
             "inherits": "2.0.3"
@@ -4973,7 +5221,8 @@
         },
         "boom": {
           "version": "2.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -4981,7 +5230,8 @@
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
@@ -4990,29 +5240,34 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
@@ -5020,22 +5275,26 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
             "boom": "2.10.1"
@@ -5043,7 +5302,8 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5052,7 +5312,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -5060,7 +5321,8 @@
         },
         "debug": {
           "version": "2.6.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5069,30 +5331,35 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5101,24 +5368,28 @@
         },
         "extend": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5129,12 +5400,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -5145,7 +5418,8 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5156,7 +5430,8 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5172,7 +5447,8 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5181,7 +5457,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -5189,7 +5466,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5202,18 +5480,21 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5223,13 +5504,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
             "boom": "2.10.1",
@@ -5240,12 +5523,14 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5256,7 +5541,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -5265,18 +5551,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -5284,24 +5573,28 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5310,19 +5603,22 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5331,19 +5627,22 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5355,7 +5654,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -5363,12 +5663,14 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "dev": true,
           "requires": {
             "mime-db": "1.27.0"
@@ -5376,7 +5678,8 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
@@ -5384,12 +5687,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -5397,13 +5702,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5422,7 +5729,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5432,7 +5740,8 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5444,24 +5753,28 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -5469,19 +5782,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5491,35 +5807,41 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5531,7 +5853,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -5539,7 +5862,8 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
           "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -5553,7 +5877,8 @@
         },
         "request": {
           "version": "2.81.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5583,7 +5908,8 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -5591,30 +5917,35 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -5622,7 +5953,8 @@
         },
         "sshpk": {
           "version": "1.13.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5639,7 +5971,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -5647,7 +5980,8 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -5657,7 +5991,8 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -5665,13 +6000,15 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -5679,13 +6016,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
             "block-stream": "0.0.9",
@@ -5695,7 +6034,8 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5711,7 +6051,8 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5720,7 +6061,8 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5729,30 +6071,35 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5761,7 +6108,8 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5770,7 +6118,8 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
       }
@@ -5813,6 +6162,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "git-repo-info": {
@@ -6007,6 +6362,66 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "hash-for-dep": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
@@ -6056,16 +6471,6 @@
       "requires": {
         "debug": "2.6.9",
         "heimdalljs": "0.2.5"
-      }
-    },
-    "home-or-tmp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-      "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2",
-        "user-home": "1.1.1"
       }
     },
     "homedir-polyfill": {
@@ -6334,17 +6739,28 @@
         "loose-envify": "1.3.1"
       }
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
-    },
     "ipaddr.js": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
       "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
       "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -6360,6 +6776,42 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "1.0.0",
+        "is-data-descriptor": "1.0.0",
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -6420,15 +6872,6 @@
         "is-extglob": "1.0.0"
       }
     },
-    "is-integer": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
-      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
-      }
-    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -6443,6 +6886,26 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
+    },
+    "is-odd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
+      "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        }
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -6466,6 +6929,23 @@
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "is-posix-bracket": {
@@ -6568,15 +7048,9 @@
       "dev": true
     },
     "js-reporters": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.0.tgz",
-      "integrity": "sha1-fPLLaYGWaEeQNQ0MTKB/Su2ewX4=",
-      "dev": true
-    },
-    "js-tokens": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-      "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
+      "integrity": "sha1-+IxgjjJKM3OpW8xFrTBeXJecRZs=",
       "dev": true
     },
     "js-yaml": {
@@ -6669,16 +7143,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
+      "optional": true
     },
     "leek": {
       "version": "0.0.24",
@@ -6690,12 +7156,6 @@
         "lodash.assign": "3.2.0",
         "rsvp": "3.6.2"
       }
-    },
-    "leven": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
-      "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM=",
-      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -6992,6 +7452,12 @@
         "lodash._slice": "2.3.0"
       }
     },
+    "lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -7224,6 +7690,12 @@
         }
       }
     },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -7250,6 +7722,21 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.4"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
       }
     },
     "markdown-it": {
@@ -7437,6 +7924,27 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
+    "mixin-deep": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
+      "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -7500,6 +8008,45 @@
       "dev": true,
       "optional": true
     },
+    "nanomatch": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
+      "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "is-odd": "1.0.0",
+        "kind-of": "5.1.0",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7511,6 +8058,15 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "1.1.4"
+      }
     },
     "node-fetch": {
       "version": "1.7.3",
@@ -7564,16 +8120,6 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
-    "npm-package-arg": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.1.tgz",
-      "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "semver": "5.4.1"
-      }
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -7611,6 +8157,82 @@
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -7619,6 +8241,23 @@
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "on-finished": {
@@ -7701,15 +8340,6 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "requires": {
-        "lcid": "1.0.0"
-      }
-    },
     "os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -7729,17 +8359,6 @@
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
-      }
-    },
-    "output-file-sync": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
       }
     },
     "p-finally": {
@@ -7814,10 +8433,10 @@
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
-    "path-exists": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-      "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-is-absolute": {
@@ -7899,6 +8518,12 @@
         }
       }
     },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -7967,12 +8592,6 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true
-    },
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
@@ -7990,47 +8609,26 @@
       }
     },
     "qunit": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.4.1.tgz",
-      "integrity": "sha512-AWAubD4gvbcFsQzb9KkkxM/BUEygIaC6yiq1aPqXyW2UAGb1uxvtwxJQ2dC2YfDFgJiAWBQJdvosAQ518BPoeQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.5.0.tgz",
+      "integrity": "sha512-GVvRr8ISFMs4SkTWFsaUzMBs7QEuiXVT4orlFgyHkmeXO1ijlDkhW6ecPri4urXiE4BUXEULJAtFlV1MWgg4Uw==",
       "dev": true,
       "requires": {
-        "chokidar": "1.6.1",
-        "commander": "2.9.0",
+        "chokidar": "1.7.0",
+        "commander": "2.12.2",
         "exists-stat": "1.0.0",
-        "findup-sync": "0.4.3",
-        "js-reporters": "1.2.0",
-        "resolve": "1.3.2",
-        "walk-sync": "0.3.1"
+        "findup-sync": "2.0.0",
+        "js-reporters": "1.2.1",
+        "resolve": "1.5.0",
+        "shelljs": "0.2.6",
+        "walk-sync": "0.3.2"
       },
       "dependencies": {
         "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
-        "resolve": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-          "integrity": "sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=",
-          "dev": true,
-          "requires": {
-            "path-parse": "1.0.5"
-          }
-        },
-        "walk-sync": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.1.tgz",
-          "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.5"
-          }
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
         }
       }
     },
@@ -8158,32 +8756,6 @@
         }
       }
     },
-    "recast": {
-      "version": "0.10.33",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-      "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
-      "dev": true,
-      "requires": {
-        "ast-types": "0.8.12",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "0.1.8",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.8.12",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-          "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
-          "dev": true
-        },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-          "dev": true
-        }
-      }
-    },
     "redeyed": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
@@ -8197,28 +8769,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
       "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
-    },
-    "regenerator": {
-      "version": "0.8.40",
-      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-      "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
-      "dev": true,
-      "requires": {
-        "commoner": "0.10.8",
-        "defs": "1.1.1",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "0.1.8",
-        "recast": "0.10.33",
-        "through": "2.3.8"
-      },
-      "dependencies": {
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-          "dev": true
-        }
-      }
     },
     "regenerator-runtime": {
       "version": "0.11.0",
@@ -8244,25 +8794,13 @@
         "is-equal-shallow": "0.1.3"
       }
     },
-    "regexpu": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-      "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
+    "regex-not": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
+      "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "recast": "0.10.33",
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        }
+        "extend-shallow": "2.0.1"
       }
     },
     "regexpu-core": {
@@ -8306,13 +8844,21 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
-    "repeating": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+    "require-folder-tree": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/require-folder-tree/-/require-folder-tree-1.4.5.tgz",
+      "integrity": "sha1-3+VTy6uYzIjhxWo/LzWPBu+FvLA=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "lodash": "3.8.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.8.0.tgz",
+          "integrity": "sha1-N265i9zZOCqTZcM8TLglDeEyW5E=",
+          "dev": true
+        }
       }
     },
     "require-uncached": {
@@ -8355,6 +8901,12 @@
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
     "restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
@@ -8370,6 +8922,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "align-text": "0.1.4"
       }
@@ -8530,11 +9083,32 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "set-getter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+      "dev": true,
+      "requires": {
+        "to-object-path": "0.3.0"
+      }
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      }
     },
     "setprototypeof": {
       "version": "1.1.0",
@@ -8555,6 +9129,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.2.6.tgz",
+      "integrity": "sha1-kEktcv/MgVmXa6umL7D2iE8MM3g=",
       "dev": true
     },
     "shellwords": {
@@ -8578,18 +9158,6 @@
         "debug": "2.6.9"
       }
     },
-    "simple-fmt": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-      "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
-      "dev": true
-    },
-    "simple-is": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-      "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
-      "dev": true
-    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -8610,6 +9178,127 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         }
+      }
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.2"
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "2.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
       }
     },
     "socket.io": {
@@ -8768,23 +9457,24 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
-    "source-map-support": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-      "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "source-map": "0.1.32"
+        "atob": "2.0.3",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-          "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+        "source-map-url": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+          "dev": true
         }
       }
     },
@@ -8839,6 +9529,36 @@
         "os-shim": "0.1.3"
       }
     },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "sprintf-js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
@@ -8850,11 +9570,83 @@
       "integrity": "sha1-p/6lw/3lXmdc8cjAbz67XCk1g14=",
       "dev": true
     },
-    "stable": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-      "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA=",
-      "dev": true
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
     },
     "statuses": {
       "version": "1.3.1",
@@ -8883,18 +9675,6 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
-    "stringmap": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-      "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
-      "dev": true
-    },
-    "stringset": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-      "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
       "dev": true
     },
     "strip-ansi": {
@@ -9094,71 +9874,6 @@
         }
       }
     },
-    "testem": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/testem/-/testem-1.18.4.tgz",
-      "integrity": "sha1-5F/tkivsL1SmFsQ/EZIlmKyX60E=",
-      "dev": true,
-      "requires": {
-        "backbone": "1.3.3",
-        "bluebird": "3.5.1",
-        "charm": "1.0.2",
-        "commander": "2.12.1",
-        "consolidate": "0.14.5",
-        "cross-spawn": "5.1.0",
-        "express": "4.16.2",
-        "fireworm": "0.7.1",
-        "glob": "7.1.2",
-        "http-proxy": "1.16.2",
-        "js-yaml": "3.10.0",
-        "lodash.assignin": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.find": "4.6.0",
-        "lodash.uniqby": "4.7.0",
-        "mkdirp": "0.5.1",
-        "mustache": "2.3.0",
-        "node-notifier": "5.1.2",
-        "npmlog": "4.1.2",
-        "printf": "0.2.5",
-        "rimraf": "2.6.2",
-        "socket.io": "1.6.0",
-        "spawn-args": "0.2.0",
-        "styled_string": "0.0.1",
-        "tap-parser": "5.4.0",
-        "xmldom": "0.1.27"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        }
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9215,6 +9930,115 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
+      "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "regex-not": "1.0.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        }
+      }
+    },
     "tree-sync": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.2.2.tgz",
@@ -9243,22 +10067,10 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
-    "try-resolve": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
-      "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI=",
-      "dev": true
-    },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
-    },
-    "tryor": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-      "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
       "dev": true
     },
     "type-check": {
@@ -9354,6 +10166,32 @@
         "util-deprecate": "1.0.2"
       }
     },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -9375,6 +10213,58 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "untildify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
@@ -9384,11 +10274,105 @@
         "os-homedir": "1.0.2"
       }
     },
-    "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "use": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
+      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        },
+        "lazy-cache": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+          "dev": true,
+          "requires": {
+            "set-getter": "0.1.0"
+          }
+        }
+      }
     },
     "username-sync": {
       "version": "1.0.1",
@@ -9485,12 +10469,6 @@
         "string-width": "1.0.2"
       }
     },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-      "dev": true
-    },
     "wordwrap": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
@@ -9570,12 +10548,6 @@
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
-    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
@@ -9590,20 +10562,6 @@
       "requires": {
         "fs-extra": "0.30.0",
         "lodash.merge": "4.6.0"
-      }
-    },
-    "yargs": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-      "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
-      "dev": true,
-      "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "os-locale": "1.4.0",
-        "window-size": "0.1.4",
-        "y18n": "3.2.1"
       }
     },
     "yeast": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2307,6 +2307,17 @@
         }
       }
     },
+    "cli-table2": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
+      "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
+      "dev": true,
+      "requires": {
+        "colors": "1.1.2",
+        "lodash": "3.10.1",
+        "string-width": "1.0.2"
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -2375,6 +2386,13 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true,
+      "optional": true
     },
     "commander": {
       "version": "2.12.1",
@@ -3708,11 +3726,81 @@
         "got": "8.1.0"
       }
     },
+    "ember-try": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.23.tgz",
+      "integrity": "sha512-kmVNsSFFafGinFhERMox3SXHoU+V1td1538SbhpslPtf7S2BZYr7JdAwOCIRoRtpcWeNdYgdQGzJZxNvUc8aLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-table2": "0.2.0",
+        "core-object": "1.1.0",
+        "debug": "2.6.9",
+        "ember-try-config": "2.2.0",
+        "extend": "3.0.1",
+        "fs-extra": "0.26.7",
+        "promise-map-series": "0.2.3",
+        "resolve": "1.5.0",
+        "rimraf": "2.6.2",
+        "rsvp": "3.6.2",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "core-object": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/core-object/-/core-object-1.1.0.tgz",
+          "integrity": "sha1-htY5GHM8+doaWq5ynmLAqI5mrQo=",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+          "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.2"
+          }
+        }
+      }
+    },
+    "ember-try-config": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-try-config/-/ember-try-config-2.2.0.tgz",
+      "integrity": "sha1-a+CvbHGUmBPgKseTVk/dv4M2uAc=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.5",
+        "node-fetch": "1.7.3",
+        "rsvp": "3.6.2",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        }
+      }
+    },
     "encodeurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
     },
     "engine.io": {
       "version": "1.8.0",
@@ -7139,6 +7227,12 @@
         }
       }
     },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+      "dev": true
+    },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
@@ -8030,6 +8124,16 @@
       "dev": true,
       "requires": {
         "lower-case": "1.1.4"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-int64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3526,6 +3526,48 @@
         }
       }
     },
+    "ember-native-dom-event-dispatcher": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/ember-native-dom-event-dispatcher/-/ember-native-dom-event-dispatcher-0.6.4.tgz",
+      "integrity": "sha512-b4BbEzxSzeIqcS9b1IA3Y8k6hWl0u0yZP3Ade1nNlQLpU213ifbece3iOi9VNdTFeX2I8sPIDHDivmJm7NoBZA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "6.11.0",
+        "ember-cli-version-checker": "2.1.0"
+      },
+      "dependencies": {
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz",
+          "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw==",
+          "dev": true,
+          "requires": {
+            "ember-rfc176-data": "0.3.1"
+          }
+        },
+        "ember-cli-babel": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.11.0.tgz",
+          "integrity": "sha512-lHQyl30lbAsMmMq2it1GO85HKrqr2gMpK5CFxmOgTJ3moBqOGMKsdV3Z0qXWpgh8Asy7pB9AACMShdgfQvSGPg==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "0.0.7",
+            "babel-plugin-debug-macros": "0.1.11",
+            "babel-plugin-ember-modules-api-polyfill": "2.3.0",
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-polyfill": "6.26.0",
+            "babel-preset-env": "1.6.1",
+            "broccoli-babel-transpiler": "6.1.2",
+            "broccoli-debug": "0.6.4",
+            "broccoli-funnel": "1.2.0",
+            "broccoli-source": "1.1.0",
+            "clone": "2.1.1",
+            "ember-cli-version-checker": "2.1.0",
+            "semver": "5.4.1"
+          }
+        }
+      }
+    },
     "ember-qunit": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-3.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-native-dom-event-dispatcher": "^0.6.4",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0",
     "ember-source-channel-url": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-cli": "~2.17.0",
+    "ember-cli": "~2.18.2",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.2",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-qunit": "^4.1.1",
+    "ember-cli-qunit": "^4.3.0",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
@@ -34,8 +34,9 @@
     "ember-load-initializers": "^1.0.0",
     "ember-native-dom-helpers": "^0.5.10",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.17.0",
-    "ember-wait-for-test-helper": "0.1.1",
+    "ember-source": "~2.18.0",
+    "eslint-plugin-ember": "^5.0.3",
+    "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
   },
   "keywords": [
@@ -48,8 +49,7 @@
     "scrollspy"
   ],
   "dependencies": {
-    "ember-cli-babel": "^6.6.0",
-    "ember-getowner-polyfill": "^2.0.0"
+    "ember-cli-babel": "^6.6.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -17,24 +17,28 @@
   },
   "author": "Lauren Tan",
   "license": "MIT",
+  "dependencies": {
+    "ember-cli-babel": "^6.6.0"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-cli": "~2.18.2",
+    "ember-cli": "~3.0.0",
     "ember-cli-dependency-checker": "^2.0.0",
-    "ember-cli-eslint": "^4.2.2",
+    "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-qunit": "^4.3.0",
+    "ember-cli-qunit": "^4.1.1",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
-    "ember-native-dom-helpers": "^0.5.10",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.18.0",
+    "ember-source": "~3.0.0",
+    "ember-source-channel-url": "^1.0.1",
     "eslint-plugin-ember": "^5.0.3",
     "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"
@@ -48,9 +52,6 @@
     "is on screen",
     "scrollspy"
   ],
-  "dependencies": {
-    "ember-cli-babel": "^6.6.0"
-  },
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "demoURL": "http://development.ember-in-viewport-demo.divshot.io"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0",
     "ember-source-channel-url": "^1.0.1",
+    "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.3",
     "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
@@ -12,11 +11,14 @@ module.exports = {
     Chrome: {
       mode: 'ci',
       args: [
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.TRAVIS ? '--no-sandbox' : null,
+
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'
-      ]
+      ].filter(Boolean)
     }
   }
 };

--- a/tests/acceptance/infinity-test.js
+++ b/tests/acceptance/infinity-test.js
@@ -1,74 +1,63 @@
-import { test } from 'qunit';
-import { findAll } from 'ember-native-dom-helpers';
-import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { find, findAll, visit, waitFor, waitUntil } from '@ember/test-helpers';
 
-moduleForAcceptance('Acceptance | infinity-scrollable', {
-  beforeEach() {
-    // bring testem window up to the top.
+module('Acceptance | infinity-scrollable', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    // bring testem window and the browser up to the top.
     document.getElementById('ember-testing-container').scrollTop = 0;
-  }
-});
+  });
 
-test('IntersectionObserver Component fetches more data when scrolled into viewport', function(assert) {
-  visit('/infinity-scrollable');
+  test('IntersectionObserver Component fetches more data when scrolled into viewport', async function(assert) {
+    await visit('/infinity-scrollable');
 
-  andThen(() => {
     assert.equal(findAll('.infinity-svg').length, 10);
     assert.equal(findAll('.infinity-scrollable.inactive').length, 1, 'component is inactive before fetching more data');
     document.querySelector('.infinity-scrollable').scrollIntoView();
-  });
 
-  waitFor('.infinity-scrollable.inactive');
+    await waitFor('.infinity-scrollable.inactive');
 
-  andThen(() => {
     assert.equal(findAll('.infinity-svg').length, 20);
     assert.equal(findAll('.infinity-scrollable.inactive').length, 1, 'component is inactive after fetching more data');
   });
-});
 
-test('rAF Component fetches more data when scrolled into viewport', function(assert) {
-  visit('/infinity-scrollable-raf');
+  test('rAF Component fetches more data when scrolled into viewport', async function(assert) {
+    await visit('/infinity-scrollable-raf');
 
-  andThen(() => {
     assert.equal(findAll('.infinity-svg-rAF').length, 10);
     assert.equal(findAll('.infinity-scrollable-rAF.inactive').length, 1, 'component is inactive before fetching more data');
     document.querySelector('.infinity-scrollable-rAF').scrollIntoView();
-  });
 
-  waitFor('.infinity-scrollable-rAF.inactive');
+    await waitFor('.infinity-scrollable-rAF.inactive');
 
-  andThen(() => {
     assert.equal(findAll('.infinity-svg-rAF').length, 20);
     assert.equal(findAll('.infinity-scrollable-rAF.inactive').length, 1, 'component is inactive after fetching more data');
   });
-});
 
-test('scrollEvent Component fetches more data when scrolled into viewport', function(assert) {
-  visit('/infinity-scrollable-scrollevent');
+  test('scrollEvent Component fetches more data when scrolled into viewport', async function(assert) {
+    await visit('/infinity-scrollable-scrollevent');
 
-  andThen(() => {
     assert.equal(findAll('.infinity-svg-scrollEvent').length, 10);
     assert.equal(findAll('.infinity-scrollable-scrollEvent.inactive').length, 1, 'component is inactive before fetching more data');
-    document.querySelector('.infinity-scrollable-scrollEvent').scrollIntoView();
-  });
+    await document.querySelector('.infinity-scrollable-scrollEvent').scrollIntoView();
 
-  waitFor(() => {
-    return find('.infinity-svg-scrollEvent').length === 20;
-  });
+    await waitUntil(() => {
+      return findAll('.infinity-svg-scrollEvent').length === 20;
+    });
 
-  andThen(() => {
     assert.equal(findAll('.infinity-svg-scrollEvent').length, 20);
-    assert.equal(find('.infinity-scrollable-scrollEvent.active').length, 1, 'component is still active after fetching more data');
+    assert.ok(find('.infinity-scrollable-scrollEvent.active'), 'component is still active after fetching more data');
     // scroll 1px to trigger inactive state
     let elem = document.getElementsByClassName('list-scrollEvent')[0];
     elem.scrollTop = elem.scrollTop + 5;
-  });
 
-  waitFor(() => {
-    return find('.infinity-scrollable-scrollEvent.inactive').length, 1;
-  });
+    await waitUntil(() => {
+      return find('.infinity-scrollable-scrollEvent.inactive');
+    });
 
-  andThen(() => {
-    assert.equal(find('.infinity-scrollable-scrollEvent.inactive').length, 1, 'component is inactive after scrolling');
+    assert.ok(find('.infinity-scrollable-scrollEvent.inactive'), 'component is inactive after scrolling');
   });
 });
+

--- a/tests/acceptance/infinity-test.js
+++ b/tests/acceptance/infinity-test.js
@@ -30,6 +30,9 @@ module('Acceptance | infinity-scrollable', function(hooks) {
     assert.equal(findAll('.infinity-scrollable-rAF.inactive').length, 1, 'component is inactive before fetching more data');
     document.querySelector('.infinity-scrollable-rAF').scrollIntoView();
 
+    await waitUntil(() => {
+      return findAll('.infinity-svg-rAF').length === 20;
+    });
     await waitFor('.infinity-scrollable-rAF.inactive');
 
     assert.equal(findAll('.infinity-svg-rAF').length, 20);

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -1,73 +1,62 @@
-import { test } from 'qunit';
-import { find } from 'ember-native-dom-helpers';
-import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { find, visit, waitFor } from '@ember/test-helpers';
 
-moduleForAcceptance('Acceptance | integration', {
-  beforeEach() {
+module('Acceptance | integration', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
     // bring testem window up to the top.
     document.getElementById('ember-testing-container').scrollTop = 0;
-  }
-});
+  });
 
-test('Component is active when in viewport', function(assert) {
-  assert.expect(1);
+  test('Component is active when in viewport', async function(assert) {
+    assert.expect(1);
 
-  visit('/');
+    await visit('/');
 
-  andThen(() => {
     assert.ok(find('.my-component.top.start-enabled.active'), 'component is active');
   });
-});
 
-test('Component is inactive when not in viewport', function(assert) {
-  assert.expect(1);
+  test('Component is inactive when not in viewport', async function(assert) {
+    assert.expect(1);
 
-  visit('/');
+    await visit('/');
 
-  andThen(() => {
     assert.ok(find('.my-component.bottom.inactive'), 'component is inactive');
   });
-});
 
-test('Component moves to active when scrolled into viewport', function(assert) {
-  assert.expect(2);
+  test('Component moves to active when scrolled into viewport', async function(assert) {
+    assert.expect(2);
 
-  visit('/');
+    await visit('/');
 
-  andThen(() => {
     assert.ok(find('.my-component.bottom.inactive'), 'component is inactive');
     document.querySelector('.my-component.bottom').scrollIntoView();
-  });
 
-  waitFor('.my-component.bottom.active');
+    await waitFor('.my-component.bottom.active');
 
-  andThen(() => {
     assert.ok(find('.my-component.bottom.active'), 'component is active');
   });
-});
 
-test('Component moves back to inactive when scrolled out of viewport', function(assert) {
-  assert.expect(1);
+  test('Component moves back to inactive when scrolled out of viewport', async function(assert) {
+    assert.expect(1);
 
-  visit('/');
+    await visit('/');
 
-  andThen(() => {
     document.querySelector('.my-component.bottom').scrollIntoView();
-  });
 
-  waitFor('.my-component.top.start-enabled.inactive');
+    await waitFor('.my-component.top.start-enabled.inactive');
 
-  andThen(() => {
     assert.ok(find('.my-component.top.start-enabled.inactive'), 'component is inactive');
   });
-});
 
-test('Component can be disabled', function(assert) {
-  assert.expect(1);
+  test('Component can be disabled', async function(assert) {
+    assert.expect(1);
 
-  visit('/');
+    await visit('/');
 
-  andThen(() => {
     assert.ok(find('.my-component.top.start-disabled.inactive'), 'component is inactive');
   });
 });
+

--- a/tests/dummy/app/components/my-component.js
+++ b/tests/dummy/app/components/my-component.js
@@ -16,14 +16,16 @@ export default Component.extend(InViewportMixin, {
       viewportIntersectionObserverOverride,
       viewportToleranceOverride,
       viewportRAFOverride,
-      scrollableAreaOverride
+      scrollableAreaOverride,
+      intersectionThresholdOverride,
     } = getProperties(this,
       'viewportSpyOverride',
       'viewportEnabledOverride',
       'viewportIntersectionObserverOverride',
       'viewportToleranceOverride',
       'viewportRAFOverride',
-      'scrollableAreaOverride'
+      'scrollableAreaOverride',
+      'intersectionThresholdOverride'
     );
 
     if (viewportSpyOverride !== undefined) {
@@ -43,6 +45,9 @@ export default Component.extend(InViewportMixin, {
     }
     if (scrollableAreaOverride !== undefined) {
       options.scrollableArea = scrollableAreaOverride;
+    }
+    if (intersectionThresholdOverride !== undefined) {
+      options.intersectionThreshold = intersectionThresholdOverride;
     }
 
     setProperties(this, options);

--- a/tests/dummy/app/components/my-component.js
+++ b/tests/dummy/app/components/my-component.js
@@ -1,5 +1,4 @@
 import Component from '@ember/component';
-import { on } from '@ember/object/evented';
 import { setProperties, getProperties, get } from '@ember/object';
 import InViewportMixin from 'ember-in-viewport';
 
@@ -7,7 +6,8 @@ export default Component.extend(InViewportMixin, {
   classNames: ['my-component'],
   classNameBindings: ['viewportEntered:active:inactive'],
 
-  viewportOptionsOverride: on('didInsertElement', function() {
+  init() {
+    this._super(...arguments);
     let options = {};
 
     let {
@@ -46,7 +46,7 @@ export default Component.extend(InViewportMixin, {
     }
 
     setProperties(this, options);
-  }),
+  },
 
   didEnterViewport() {
     if (get(this, 'infinityLoad')) {

--- a/tests/dummy/app/controllers/infinity-scrollable.js
+++ b/tests/dummy/app/controllers/infinity-scrollable.js
@@ -8,8 +8,11 @@ let line = '<line x1="10" x2="50" y1="110" y2="150" stroke="orange" stroke-width
 const images = [rect, circle, line];
 
 export default Controller.extend({
-  viewportToleranceOverride: {
-    top: 1
+  init() {
+    this._super(...arguments);
+    this.viewportToleranceOverride = {
+      top: 1
+    }
   },
 
   actions: {

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -23,3 +23,9 @@
 #ember-testing-container {
   margin-bottom: 500px !important;
 }
+
+.infinity-container {
+  border: 1px solid black;
+  height: 500px;
+  overflow: scroll;
+}

--- a/tests/dummy/app/templates/infinity-scrollable-raf.hbs
+++ b/tests/dummy/app/templates/infinity-scrollable-raf.hbs
@@ -1,4 +1,4 @@
-<div class="list-rAF" style="height: 500px; overflow: scroll;">
+<div class="list-rAF infinity-container">
   <ul>
     {{#each model as |val|}}
     <div class="infinity-svg-rAF">
@@ -8,8 +8,8 @@
     </div>
     {{/each}}
   </ul>
-  {{my-component 
-    class="infinity-scrollable-rAF" 
+  {{my-component
+    class="infinity-scrollable-rAF"
     viewportSpyOverride=true
     viewportIntersectionObserverOverride=false
     scrollableAreaOverride=".list-rAF"

--- a/tests/dummy/app/templates/infinity-scrollable-scrollevent.hbs
+++ b/tests/dummy/app/templates/infinity-scrollable-scrollevent.hbs
@@ -1,4 +1,4 @@
-<div class="list-scrollEvent" style="height: 500px; overflow: scroll;">
+<div class="list-scrollEvent infinity-container">
   <ul>
     {{#each model as |val|}}
     <div class="infinity-svg-scrollEvent">

--- a/tests/dummy/app/templates/infinity-scrollable.hbs
+++ b/tests/dummy/app/templates/infinity-scrollable.hbs
@@ -1,4 +1,4 @@
-<div class="list" style="height: 500px; overflow: scroll;">
+<div class="list infinity-container">
   <ul>
     {{#each model as |val|}}
       <div class="infinity-svg">

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = function(environment) {
@@ -41,6 +40,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.autoboot = false;
   }
 
   if (environment === 'production') {

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   browsers: [
     'ie 9',

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,8 +1,16 @@
+const browsers = [
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions'
+];
+
+const isCI = !!process.env.CI;
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
+
 module.exports = {
-  browsers: [
-    'ie 9',
-    'last 1 Chrome versions',
-    'last 1 Firefox versions',
-    'last 1 Safari versions'
-  ]
+  browsers
 };

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,10 +2,10 @@ import Application from '../../app';
 import config from '../../config/environment';
 import { merge } from '@ember/polyfills';
 import { run } from '@ember/runloop';
-import 'ember-wait-for-test-helper/wait-for';
 
 export default function startApp(attrs) {
   let attributes = merge({}, config.APP);
+  attributes.autoboot = true;
   attributes = merge(attributes, attrs); // use defaults, but you can override;
 
   return run(() => {

--- a/tests/integration/components/my-component-test.js
+++ b/tests/integration/components/my-component-test.js
@@ -1,37 +1,39 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('my-component', 'Integration | Component | my component', {
-  integration: true
-});
+module('Integration | Component | my component', function(hooks) {
+  setupRenderingTest(hooks);
 
-test('it renders with viewportTolerance partially set', function(assert) {
-  // viewportTolerance && viewportEnabled is usually setup in the initializer. Needs defaults
-  this.viewportToleranceOverride = {
-    top: 1
-  };
-  this.render(hbs`
-    {{#my-component viewportEnabled=true viewportToleranceOverride=viewportToleranceOverride}}
-      template block text
-    {{/my-component}}
-  `);
+  test('it renders with viewportTolerance partially set', async function(assert) {
+    // viewportTolerance && viewportEnabled is usually setup in the initializer. Needs defaults
+    this.viewportToleranceOverride = {
+      top: 1
+    };
+    await render(hbs`
+      {{#my-component viewportEnabled=true viewportToleranceOverride=viewportToleranceOverride}}
+        template block text
+      {{/my-component}}
+    `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
-});
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
 
-test('it renders with intersectionThreshold set', function(assert) {
-  this.viewportTolerance = {
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-  };
-  this.intersectionThreshold = 1.0;
-  this.render(hbs`
-    {{#my-component viewportEnabled=true viewportTolerance=viewportTolerance intersectionThreshold=intersectionThreshold}}
-      template block text
-    {{/my-component}}
-  `);
+  test('it renders with intersectionThreshold set', async function(assert) {
+    this.viewportTolerance = {
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+    };
+    this.intersectionThreshold = 1.0;
+    await render(hbs`
+      {{#my-component viewportEnabled=true viewportTolerance=viewportTolerance intersectionThreshold=intersectionThreshold}}
+        template block text
+      {{/my-component}}
+    `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
 });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,8 @@
 import Application from '../app';
+import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 
-setApplication(Application.create({ autoboot: false }));
+setApplication(Application.create(config.APP));
 
 start();

--- a/tests/unit/initializers/viewport-config-test.js
+++ b/tests/unit/initializers/viewport-config-test.js
@@ -2,12 +2,15 @@ import Application from '@ember/application';
 import { run } from '@ember/runloop';
 import ViewportConfigInitializer from 'dummy/initializers/viewport-config';
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
 const { keys } = Object;
 
 let container, application;
 
 module('Unit | Initializer | viewport config', function(hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function() {
     run(function() {
       application = Application.create();

--- a/tests/unit/initializers/viewport-config-test.js
+++ b/tests/unit/initializers/viewport-config-test.js
@@ -7,25 +7,25 @@ const { keys } = Object;
 
 let container, application;
 
-module('Unit | Initializer | viewport config', {
-  beforeEach() {
+module('Unit | Initializer | viewport config', function(hooks) {
+  hooks.beforeEach(function() {
     run(function() {
       application = Application.create();
       container = application.__container__;
       application.register('config:environment', {});
       application.deferReadiness();
     });
-  }
-});
+  });
 
-test('it has a viewportConfig object', function(assert) {
-  ViewportConfigInitializer.initialize(application);
+  test('it has a viewportConfig object', function(assert) {
+    ViewportConfigInitializer.initialize(application);
 
-  const viewportConfig = container.lookup('config:in-viewport');
-  const viewportConfigKeys = keys(viewportConfig);
+    const viewportConfig = container.lookup('config:in-viewport');
+    const viewportConfigKeys = keys(viewportConfig);
 
-  assert.ok(viewportConfig);
-  assert.ok(viewportConfigKeys.length);
-  assert.ok(viewportConfigKeys.includes('intersectionThreshold'), 'intersectionThreshold is in viewportConfig');
-  assert.ok(viewportConfigKeys.includes('scrollableArea'), 'scrollableArea is in viewportConfig');
+    assert.ok(viewportConfig);
+    assert.ok(viewportConfigKeys.length);
+    assert.ok(viewportConfigKeys.includes('intersectionThreshold'), 'intersectionThreshold is in viewportConfig');
+    assert.ok(viewportConfigKeys.includes('scrollableArea'), 'scrollableArea is in viewportConfig');
+  });
 });

--- a/tests/unit/mixins/in-viewport-test.js
+++ b/tests/unit/mixins/in-viewport-test.js
@@ -1,12 +1,12 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 import InViewportMixin from 'ember-in-viewport/mixins/in-viewport';
 import { module, test } from 'qunit';
 
-module('Unit | Mixin | in viewport');
-
-// Replace this with your real tests.
-test('it works', function(assert) {
-  let InViewportObject = Ember.Object.extend(InViewportMixin);
-  let subject = InViewportObject.create();
-  assert.ok(subject);
+module('Unit | Mixin | in viewport', function() {
+  // Replace this with your real tests.
+  test('it works', function(assert) {
+    let InViewportObject = EmberObject.extend(InViewportMixin);
+    let subject = InViewportObject.create();
+    assert.ok(subject);
+  });
 });

--- a/tests/unit/mixins/in-viewport-test.js
+++ b/tests/unit/mixins/in-viewport-test.js
@@ -1,8 +1,11 @@
 import EmberObject from '@ember/object';
 import InViewportMixin from 'ember-in-viewport/mixins/in-viewport';
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-module('Unit | Mixin | in viewport', function() {
+module('Unit | Mixin | in viewport', function(hooks) {
+  setupTest(hooks);
+
   // Replace this with your real tests.
   test('it works', function(assert) {
     let InViewportObject = EmberObject.extend(InViewportMixin);

--- a/tests/unit/utils/check-scroll-direction-test.js
+++ b/tests/unit/utils/check-scroll-direction-test.js
@@ -1,9 +1,12 @@
 import checkScrollDirection from 'ember-in-viewport/utils/check-scroll-direction';
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
 let lastPosition;
 
 module('Unit | Utility | check scroll direction', function(hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function() {
     lastPosition = {
       top: 300,

--- a/tests/unit/utils/check-scroll-direction-test.js
+++ b/tests/unit/utils/check-scroll-direction-test.js
@@ -3,46 +3,46 @@ import { module, test } from 'qunit';
 
 let lastPosition;
 
-module('Unit | Utility | check scroll direction', {
-  beforeEach() {
+module('Unit | Utility | check scroll direction', function(hooks) {
+  hooks.beforeEach(function() {
     lastPosition = {
       top: 300,
       left: 150
     };
-  }
-});
-
-test('returns the right direction', function(assert) {
-  const movements = [
-    { direction: 'down',  position: { top: 400, left: 150 } },
-    { direction: 'up',    position: { top: 200, left: 150 } },
-    { direction: 'right', position: { top: 300, left: 250 } },
-    { direction: 'left',  position: { top: 300, left: 100 } }
-  ];
-
-  assert.expect(movements.length);
-
-  movements.forEach((movement) => {
-    const { direction, position } = movement;
-    const scrollDirection = checkScrollDirection(lastPosition, position);
-
-    assert.equal(direction, scrollDirection);
   });
-});
 
-test('adjusts for sensitivity', function(assert) {
-  const movements = [
-    { direction: undefined, position: { top: 399, left: 150 } },
-    { direction: 'down',    position: { top: 400, left: 150 } },
-    { direction: 'down',    position: { top: 500, left: 250 } }
-  ];
+  test('returns the right direction', function(assert) {
+    const movements = [
+      { direction: 'down',  position: { top: 400, left: 150 } },
+      { direction: 'up',    position: { top: 200, left: 150 } },
+      { direction: 'right', position: { top: 300, left: 250 } },
+      { direction: 'left',  position: { top: 300, left: 100 } }
+    ];
 
-  assert.expect(movements.length);
+    assert.expect(movements.length);
 
-  movements.forEach((movement) => {
-    const { direction, position } = movement;
-    const scrollDirection = checkScrollDirection(lastPosition, position, 100);
+    movements.forEach((movement) => {
+      const { direction, position } = movement;
+      const scrollDirection = checkScrollDirection(lastPosition, position);
 
-    assert.equal(direction, scrollDirection);
+      assert.equal(direction, scrollDirection);
+    });
+  });
+
+  test('adjusts for sensitivity', function(assert) {
+    const movements = [
+      { direction: undefined, position: { top: 399, left: 150 } },
+      { direction: 'down',    position: { top: 400, left: 150 } },
+      { direction: 'down',    position: { top: 500, left: 250 } }
+    ];
+
+    assert.expect(movements.length);
+
+    movements.forEach((movement) => {
+      const { direction, position } = movement;
+      const scrollDirection = checkScrollDirection(lastPosition, position, 100);
+
+      assert.equal(direction, scrollDirection);
+    });
   });
 });

--- a/tests/unit/utils/is-in-viewport-test.js
+++ b/tests/unit/utils/is-in-viewport-test.js
@@ -3,8 +3,8 @@ import { module, test } from 'qunit';
 
 let fakeRectNotInViewport, fakeRectInViewport, fakeWindow, fakeNoTolerance, fakeTolerance;
 
-module('Unit | Utility | is in viewport', {
-  beforeEach() {
+module('Unit | Utility | is in viewport', function(hooks) {
+  hooks.beforeEach(function() {
     fakeRectNotInViewport = {
       top: 450,
       left: 150,
@@ -35,75 +35,75 @@ module('Unit | Utility | is in viewport', {
       top: 200,
       bottom: 200
     };
-  }
-});
+  });
 
-test('returns true if dimensions are within viewport', function(assert) {
-  const { innerHeight, innerWidth } = fakeWindow;
-  const result = isInViewport(fakeRectInViewport, innerHeight, innerWidth, fakeNoTolerance);
-  assert.ok(result);
-});
+  test('returns true if dimensions are within viewport', function(assert) {
+    const { innerHeight, innerWidth } = fakeWindow;
+    const result = isInViewport(fakeRectInViewport, innerHeight, innerWidth, fakeNoTolerance);
+    assert.ok(result);
+  });
 
-test('returns false if dimensions not within viewport', function(assert) {
-  const { innerHeight, innerWidth } = fakeWindow;
-  const result = isInViewport(fakeRectNotInViewport, innerHeight, innerWidth, fakeNoTolerance);
-  assert.ok(!result);
-});
+  test('returns false if dimensions not within viewport', function(assert) {
+    const { innerHeight, innerWidth } = fakeWindow;
+    const result = isInViewport(fakeRectNotInViewport, innerHeight, innerWidth, fakeNoTolerance);
+    assert.ok(!result);
+  });
 
-test('returns true if dimensions not within viewport but within tolerance', function(assert) {
-  const { innerHeight, innerWidth } = fakeWindow;
-  const result = isInViewport(fakeRectNotInViewport, innerHeight, innerWidth, fakeTolerance);
-  assert.ok(result);
-});
+  test('returns true if dimensions not within viewport but within tolerance', function(assert) {
+    const { innerHeight, innerWidth } = fakeWindow;
+    const result = isInViewport(fakeRectNotInViewport, innerHeight, innerWidth, fakeTolerance);
+    assert.ok(result);
+  });
 
-test('returns true if rect with subpixel height is within viewport', function(assert) {
-  const innerHeight = 400;
-  const innerWidth = 1280;
-  const fakeRectWithSubpixelsInViewport = {
-    top: 300,
-    left: 150,
-    bottom: 400.4,
-    right: 1130
-  };
-  const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
-  assert.ok(result);
-});
+  test('returns true if rect with subpixel height is within viewport', function(assert) {
+    const innerHeight = 400;
+    const innerWidth = 1280;
+    const fakeRectWithSubpixelsInViewport = {
+      top: 300,
+      left: 150,
+      bottom: 400.4,
+      right: 1130
+    };
+    const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
+    assert.ok(result);
+  });
 
-test('returns true if rect with subpixel width is within viewport', function(assert) {
-  const innerHeight = 400;
-  const innerWidth = 1280;
-  const fakeRectWithSubpixelsInViewport = {
-    top: 300,
-    left: 150,
-    bottom: 400,
-    right: 1280.4
-  };
-  const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
-  assert.ok(result);
-});
+  test('returns true if rect with subpixel width is within viewport', function(assert) {
+    const innerHeight = 400;
+    const innerWidth = 1280;
+    const fakeRectWithSubpixelsInViewport = {
+      top: 300,
+      left: 150,
+      bottom: 400,
+      right: 1280.4
+    };
+    const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
+    assert.ok(result);
+  });
 
-test('returns false if rect with subpixel height is not within viewport', function(assert) {
-  const innerHeight = 400;
-  const innerWidth = 1280;
-  const fakeRectWithSubpixelsInViewport = {
-    top: 300,
-    left: 150,
-    bottom: 400.8,
-    right: 1130
-  };
-  const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
-  assert.notOk(result);
-});
+  test('returns false if rect with subpixel height is not within viewport', function(assert) {
+    const innerHeight = 400;
+    const innerWidth = 1280;
+    const fakeRectWithSubpixelsInViewport = {
+      top: 300,
+      left: 150,
+      bottom: 400.8,
+      right: 1130
+    };
+    const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
+    assert.notOk(result);
+  });
 
-test('returns false if rect with subpixel width is not within viewport', function(assert) {
-  const innerHeight = 400;
-  const innerWidth = 1280;
-  const fakeRectWithSubpixelsInViewport = {
-    top: 300,
-    left: 150,
-    bottom: 400,
-    right: 1280.7
-  };
-  const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
-  assert.notOk(result);
+  test('returns false if rect with subpixel width is not within viewport', function(assert) {
+    const innerHeight = 400;
+    const innerWidth = 1280;
+    const fakeRectWithSubpixelsInViewport = {
+      top: 300,
+      left: 150,
+      bottom: 400,
+      right: 1280.7
+    };
+    const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
+    assert.notOk(result);
+  });
 });

--- a/tests/unit/utils/is-in-viewport-test.js
+++ b/tests/unit/utils/is-in-viewport-test.js
@@ -1,9 +1,12 @@
 import isInViewport from 'ember-in-viewport/utils/is-in-viewport';
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
 let fakeRectNotInViewport, fakeRectInViewport, fakeWindow, fakeNoTolerance, fakeTolerance;
 
 module('Unit | Utility | is in viewport', function(hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function() {
     fakeRectNotInViewport = {
       top: 450,


### PR DESCRIPTION
Still got some work to do here.  Previous implementation for scroll listeners did something to the effect of `scroll.elementId` whereas now it just simply listens for `scroll`.  Need to look into if this could break anything.

- [x] upgrade to 3.0
- [x] replace usage of jquery
- [x] properly remove jquery


Closes #118 

