### PR TITLE
change intersection threshold default to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ export default Ember.Component.extend(InViewportMixin, {
       viewportUseIntersectionObserver : true,
       viewportScrollSensitivity       : 1,
       viewportRefreshRate             : 150,
-      intersectionThreshold           : 1.0,
+      intersectionThreshold           : 0,
       scrollableArea                  : null,
       viewportTolerance: {
         top    : 50,
@@ -112,11 +112,12 @@ export default Ember.Component.extend(InViewportMixin, {
   (https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
   (https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds#Browser_compatibility)
 
-- `intersectionThreshold: decimal`
+- `intersectionThreshold: decimal or array`
 
-  Default: 1.0
+  Default: 0
 
   A single number or array of numbers between 0.0 and 1.0.  A value of 0.0 means the target will be visible when the first pixel enters the viewport.  A value of 1.0 means the entire target must be visible to fire the didEnterViewport hook.
+  Similarily, [0, .25, .5, .75, 1] will fire didEnterViewport every 25% of the target that is visible.
   (https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Thresholds)
 
 - `scrollableArea`
@@ -173,7 +174,7 @@ module.exports = function(environment) {
       viewportScrollSensitivity       : 1,
       viewportRefreshRate             : 100,
       viewportListeners               : [],
-      intersectionThreshold           : 1.0,
+      intersectionThreshold           : 0,
       scrollableArea                  : null,
       viewportTolerance: {
         top    : 0,

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ export default Ember.Component.extend(InViewportMixin, {
   (https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Thresholds)
 
   Some notes:
-    - If the target is offscreen, you will get a notification via didExitViewport that the target is initially offscreen.  Similarily, this is possible to notify if onscreen when your site loads.
-    - If intersectionThreshold is set to anything greater than 0, you will not see didExitViewport hook fired due to our use of the isIntersecting property.
-    - If your intersectionThreshold is set to [0,1] you will get notified if the target didEnterViewport and didExitViewport at the appropriate time.
+    - If the target is offscreen, you will get a notification via `didExitViewport` that the target is initially offscreen.  Similarily, this is possible to notify if onscreen when your site loads.
+    - If intersectionThreshold is set to anything greater than 0, you will not see `didExitViewport` hook fired due to our use of the `isIntersecting` property.  See last comment here: https://bugs.chromium.org/p/chromium/issues/detail?id=713819 for purpose of `isIntersecting`
+    - If your intersectionThreshold is set to 0 you will get notified if the target `didEnterViewport` and `didExitViewport` at the appropriate time.
 
 - `scrollableArea`
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ export default Ember.Component.extend(InViewportMixin, {
   Similarily, [0, .25, .5, .75, 1] will fire didEnterViewport every 25% of the target that is visible.
   (https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Thresholds)
 
+  Some notes:
+    - If the target is offscreen, you will get a notification via didExitViewport that the target is initially offscreen.  Similarily, this is possible to notify if onscreen when your site loads.
+    - If intersectionThreshold is set to anything greater than 0, you will not see didExitViewport hook fired due to our use of the isIntersecting property.
+    - If your intersectionThreshold is set to [0,1] you will get notified if the target didEnterViewport and didExitViewport at the appropriate time.
+
 - `scrollableArea`
 
   Default: null

--- a/addon/initializers/viewport-config.js
+++ b/addon/initializers/viewport-config.js
@@ -16,7 +16,7 @@ const defaultConfig = {
     bottom: 0,
     right: 0
   },
-  intersectionThreshold: 1.0,
+  intersectionThreshold: 0,
   scrollableArea: null // defaults to layout view (document.documentElement)
 };
 


### PR DESCRIPTION
To be inline with the IntersectionObserver spec, I think we should make the `threshold` value default to 0, meaning the `didEnterViewport` will trigger when the first pixel of the `target` has entered the scrollable area.