### PR TITLE
Cancel animation frame before requesting again

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -129,8 +129,14 @@ export default Mixin.create({
             get(this, 'viewportTolerance')
           )
         );
+
         if (get(this, 'viewportUseRAF')) {
-          rAFIDS[get(this, 'elementId')] = window.requestAnimationFrame(
+          let elementId = get(this, 'elementId');
+
+          if (rAFIDS[elementId]) {
+            window.cancelAnimationFrame(rAFIDS[elementId]);
+          }
+          rAFIDS[elementId] = window.requestAnimationFrame(
             bind(this, this._setViewportEntered)
           );
         }


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes #42 

## Changes proposed in this pull request

When looking into performance issues with our app we discovered that the `requestAnimationFrame` approach is really noisy on the main thread.  We noticed after all images had been lazy loaded it was still ticking away requesting animation frames indefinitely.  We want to cancel the previous request before losing track of the current request id. 

~2 seconds of recorded performance:

<img width="924" alt="screen shot 2018-04-24 at 4 52 46 pm" src="https://user-images.githubusercontent.com/222011/39215168-ec0b4980-47e4-11e8-8c62-0f58e33cddf3.png">

Each of these is a call to `_setViewportEntered`, one for each lazy image on the screen. Called 60fps waiting for an element to enter the screen.

<img width="1316" alt="screen shot 2018-04-24 at 5 00 34 pm" src="https://user-images.githubusercontent.com/222011/39215169-ec1bed44-47e4-11e8-804b-8eafc77e920d.png">

Once all images have been loaded, the main thread is now quiet.

<img width="1339" alt="screen shot 2018-04-24 at 5 18 50 pm" src="https://user-images.githubusercontent.com/222011/39215207-0f47eb4c-47e5-11e8-9d8d-bffa0d1954ca.png">

