### PR TITLE
Ensure explicitly setting viewportUseIntersectionObserver is not allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ export default Component.extend(InViewportMixin, {
       viewportEnabled                 : true,
       viewportUseRAF                  : true,
       viewportSpy                     : false,
-      viewportUseIntersectionObserver : true,
       viewportScrollSensitivity       : 1,
       viewportRefreshRate             : 150,
       intersectionThreshold           : 0,
@@ -114,8 +113,9 @@ export default Component.extend(InViewportMixin, {
 - `viewportUseIntersectionObserver: boolean`
 
   Default: Depends on browser
+  Read-only
 
-  The Mixin by default will use the IntersectionObserver API. If IntersectionObserver is not supported in the target browser, ember-in-viewport will fallback to rAF.
+  The Mixin by default will use the IntersectionObserver API. If IntersectionObserver is not supported in the target browser, ember-in-viewport will fallback to rAF.  We prevent users from explicitly setting this to `true` as browsers lacking support for IntersectionObserver will throw an error.
 
   (https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
   (https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds#Browser_compatibility)
@@ -191,7 +191,6 @@ module.exports = function(environment) {
       viewportEnabled                 : false,
       viewportUseRAF                  : true,
       viewportSpy                     : false,
-      viewportUseIntersectionObserver : true,
       viewportScrollSensitivity       : 1,
       viewportRefreshRate             : 100,
       viewportListeners               : [],

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -54,12 +54,16 @@ export default Mixin.create({
     // ensure this mixin runs first, then your component can override the options
     this._super(...arguments);
 
-    const options = assign({
+    let options = assign({
       viewportUseRAF: canUseRAF(),
-      viewportUseIntersectionObserver: canUseIntersectionObserver(),
       viewportEntered: false,
       viewportListeners: []
     }, this._buildOptions());
+
+    // set viewportUseIntersectionObserver after merging users config to avoid errors in browsers that lack support (https://github.com/DockYard/ember-in-viewport/issues/146)
+    options = assign(options, {
+      viewportUseIntersectionObserver: canUseIntersectionObserver(),
+    });
 
     setProperties(this, options);
     set(this, '_evtListenerClosures', []);


### PR DESCRIPTION
Closes #146 

## Changes proposed in this pull request
If the user sets `viewportUseIntersectionObserver`, we will override it with our internal check to see if the mixin can support Intersection Observer.
