### PR TITLE
rAF service reinitialisation issue

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -130,6 +130,7 @@ export default Mixin.create({
       });
     } else {
       return scheduleOnce('afterRender', this, () => {
+        this.get('_rAFAdmin').restart();
         this._setViewportEntered();
       });
     }

--- a/addon/services/-raf-admin.js
+++ b/addon/services/-raf-admin.js
@@ -30,6 +30,13 @@ export default class RAFAdmin extends Service {
     });
   }
 
+  restart() {
+    if (!this.isRunning) {
+      this.isRunning = true;
+      this.flush();
+    }
+  }
+
   add(elementId, fn) {
     this.pool.push({ [elementId]: fn });
     return fn;


### PR DESCRIPTION
rAF service is now capable of restarting in case of an element change without reinitializing the service

This is a fix for an issue I had where ember-infinity loaded a list of clickable elements. Each of these elements navigated to it's own sub-page. Upon returning from the sub-page to the main page with the infinity loader, the infinity-loader element had been destroyed and re-initialised, causing the cancel function of ember-in-viewport's rAF service to be triggered. Since the service was never reinitialised, the isRunning flag remained false even though we now have a new element which required listening to.

(Issue only occured in Safari/iOS)