### PR TITLE
Ensure if elements with different options using same root create new IntersectionObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,14 @@ The mixin comes with some options. Due to the way listeners and `IntersectionObs
 
 ```js
 import Component from '@ember/component';
+import { setProperties } from '@ember/object';
 
 export default Component.extend(InViewportMixin, {
   init() {
     this._super(...arguments);
 
-    Ember.setProperties(this, {
+    setProperties(this, {
+      viewportDescriptor              : null,
       viewportEnabled                 : true,
       viewportUseRAF                  : true,
       viewportSpy                     : false,
@@ -188,7 +190,7 @@ export default Component.extend(InViewportMixin, {
 
   Default: `null`
 
-  This option tells in-viewport that you have multiple items you want to observe on the same page; however, since you might have multiple elements on the page with the same `scrollableArea` but different options (e.g. `viewportTolerance`), it is necessary to let ember-in-viewport know that we should treat those two elements differently.
+  This option tells ember-in-viewport that you have multiple items you want to observe on the same page.  However, since you might have multiple elements on the page with the same `scrollableArea` but different options (e.g. `viewportTolerance`), it is necessary to let ember-in-viewport know that we should treat those two elements differently.
 
   The reason this is important is because we optimize the IntersectionObserver to reuse the instance instead of creating another IntersectionObserver for every item on the page.  However, due to this optimization, we need to know if the items on the page you want to observe are of different types - see example below:
 
@@ -203,13 +205,13 @@ module.exports = function(environment) {
   var ENV = {
     // ...
     viewportConfig: {
+      viewportDescriptor              : null,
       viewportEnabled                 : false,
       viewportUseRAF                  : true,
       viewportSpy                     : false,
       viewportScrollSensitivity       : 1,
       viewportRefreshRate             : 100,
       viewportListeners               : [],
-      viewportDescriptor              : null,
       intersectionThreshold           : 0,
       scrollableArea                  : null,
       viewportTolerance: {

--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ export default Component.extend(InViewportMixin, {
 
   Also, if your sentinel (component that uses this mixin) is a zero-height element, ensure that the sentinel actually is able to enter the viewport.
 
+- `viewportDescriptor: string`
+
+  Default: `null`
+
+  This option tells in-viewport that you have multiple items you want to observe on the same page; however, since you might have multiple elements on the page with the same `scrollableArea` but different options (e.g. `viewportTolerance`), it is necessary to let ember-in-viewport know that we should treat those two elements differently.
+
+  The reason this is important is because we optimize the IntersectionObserver to reuse the instance instead of creating another IntersectionObserver for every item on the page.  However, due to this optimization, we need to know if the items on the page you want to observe are of different types - see example below:
+
+  e.g. `artwork` and `infinityLoader` would be two examples of `viewportDescriptor` where they both use the same `scrollableArea` (window or element) but may have different config options such as `viewportTolerance`, `viewportSpy`, etc;
+
 ### Global options
 
 You can set application wide defaults for `ember-in-viewport` in your app (they are still manually overridable inside of a Component). To set new defaults, just add a config object to `config/environment.js`, like so:
@@ -199,6 +209,7 @@ module.exports = function(environment) {
       viewportScrollSensitivity       : 1,
       viewportRefreshRate             : 100,
       viewportListeners               : [],
+      viewportDescriptor              : null,
       intersectionThreshold           : 0,
       scrollableArea                  : null,
       viewportTolerance: {

--- a/addon/initializers/viewport-config.js
+++ b/addon/initializers/viewport-config.js
@@ -3,6 +3,7 @@ import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
 
 const defaultConfig = {
   viewportEnabled: true,
+  viewportDescriptor: null,
   viewportSpy: false,
   viewportScrollSensitivity: 1,
   viewportRefreshRate: 100,

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -355,7 +355,7 @@ export default Mixin.create({
 
     // if IntersectionObserver
     if (get(this, 'viewportUseIntersectionObserver')) {
-      get(this, '_observerAdmin').unobserve(this.element, this.viewportDescriptor || get(this, '_observerOptions.root'));
+      get(this, '_observerAdmin').unobserve(this.element, { viewportDescriptor: this.viewportDescriptor } || get(this, '_observerOptions.root'));
     }
 
     // if rAF

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -155,7 +155,7 @@ export default Mixin.create({
       threshold: get(this, 'intersectionThreshold')
     };
 
-    get(this, '_observerAdmin').add(element, bind(this, this._onEnterIntersection), bind(this, this._onExitIntersection), this._observerOptions);
+    get(this, '_observerAdmin').add(element, bind(this, this._onEnterIntersection), bind(this, this._onExitIntersection), this._observerOptions, this.viewportDescriptor);
   },
 
   /**
@@ -355,7 +355,7 @@ export default Mixin.create({
 
     // if IntersectionObserver
     if (get(this, 'viewportUseIntersectionObserver')) {
-      get(this, '_observerAdmin').unobserve(this.element, get(this, '_observerOptions.root'));
+      get(this, '_observerAdmin').unobserve(this.element, this.viewportDescriptor || get(this, '_observerOptions.root'));
     }
 
     // if rAF

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -28,21 +28,18 @@ export default class ObserverAdmin extends Service {
   add(element, enterCallback, exitCallback, observerOptions, viewportDescriptor) {
     let { root = window } = observerOptions;
     // we will set the main key we store the intersectionObserver instance on either viewportDescriptor or root
-    let descriptor = viewportDescriptor || root;
+    let descriptor = { viewportDescriptor } || root;
     let { elements, intersectionObserver } = this._findRoot(descriptor);
 
     if (elements && elements.length > 0) {
       // if same observerOptions found in another element already being observed, then we can add to existing intersection observer and return early
-      if (this._hasSimilarElement(observerOptions, elements)) {
-        elements.push({ element, enterCallback, exitCallback, observerOptions });
-        intersectionObserver.observe(element);
-        return;
-      }
+      elements.push({ element, enterCallback, exitCallback, observerOptions });
+      intersectionObserver.observe(element);
+    } else {
+      let newIO = new IntersectionObserver(bind(this, this._setupOnIntersection(descriptor)), observerOptions);
+      newIO.observe(element);
+      DOMRef.set(descriptor, { elements: [{ element, enterCallback, exitCallback, observerOptions }], intersectionObserver: newIO });
     }
-
-    let newIO = new IntersectionObserver(bind(this, this._setupOnIntersection(descriptor)), observerOptions);
-    newIO.observe(element);
-    DOMRef.set(descriptor, { elements: [{ element, enterCallback, exitCallback, observerOptions }], intersectionObserver: newIO });
   }
 
   /**
@@ -124,44 +121,5 @@ export default class ObserverAdmin extends Service {
    */
   _findRoot(descriptor) {
     return DOMRef.get(descriptor) || {};
-  }
-
-  /**
-   * determine if existing elements for a given `root` || viewportDescriptor have the same observerOptions
-   * @method _hasSimilarElement
-   */
-  _hasSimilarElement(observerOptions, elements) {
-    return elements.some((testElement) => {
-      return this._compareOptions(observerOptions, testElement.observerOptions);
-    });
-  }
-
-  /**
-   * We need to test this because two elements may be using the same `root` but have different observerOptions
-   * i.e. viewportTolerance bottom 500px vs bottom 0px
-   * We only compare primitive types and objects; not arrays or functions
-   *
-   * @method _compareOptions
-   */
-  _compareOptions(observerOptions, elementOptions) {
-    // simple comparison of string, number or even null/undefined
-    let type1 = Object.prototype.toString.call(observerOptions);
-    let type2 = Object.prototype.toString.call(elementOptions);
-    if (type1 !== type2) {
-      return false;
-    } else if (type1 !== '[object Object]' && type2 !== '[object Object]') {
-      return observerOptions === elementOptions;
-    }
-
-    // complex comparison for only type of [object Object]
-    for (let key in observerOptions) {
-      if (observerOptions.hasOwnProperty(key)) {
-        // recursion to check nested
-        if (this._compareOptions(observerOptions[key], elementOptions[key]) === false) {
-          return false;
-        }
-      }
-    }
-    return true;
   }
 }

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -70,12 +70,22 @@ export default class ObserverAdmin extends Service {
     }
   }
 
+  /**
+   * @method _setupOnIntersection
+   * @param {window|String} descriptor
+   */
   _setupOnIntersection(descriptor) {
     return function(entries) {
       return this._onAdminIntersection(descriptor, entries);
     }
   }
 
+  /**
+   * callback when the observer is triggered
+   * @method _onAdminIntersection
+   * @param {window|String} descriptor
+   * @param {Array} ioEntries
+   */
   _onAdminIntersection(descriptor, ioEntries) {
     ioEntries.forEach((entry) => {
 

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { bind } from '@ember/runloop';
 
-// WeakMap { root || viewportDescriptor : { elements: [{ element, enterCallback, exitCallback, observerOptions }], IntersectionObserver } }
+// WeakMap { root || viewportDescriptor : { elements: [{ element, enterCallback, exitCallback }], IntersectionObserver } }
 let DOMRef = new WeakMap();
 
 /**
@@ -33,12 +33,12 @@ export default class ObserverAdmin extends Service {
 
     if (elements && elements.length > 0) {
       // if same observerOptions found in another element already being observed, then we can add to existing intersection observer and return early
-      elements.push({ element, enterCallback, exitCallback, observerOptions });
+      elements.push({ element, enterCallback, exitCallback });
       intersectionObserver.observe(element);
     } else {
       let newIO = new IntersectionObserver(bind(this, this._setupOnIntersection(descriptor)), observerOptions);
       newIO.observe(element);
-      DOMRef.set(descriptor, { elements: [{ element, enterCallback, exitCallback, observerOptions }], intersectionObserver: newIO });
+      DOMRef.set(descriptor, { elements: [{ element, enterCallback, exitCallback }], intersectionObserver: newIO });
     }
   }
 

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { bind } from '@ember/runloop';
 
-// WeakMap { root: { elements: [{ element, enterCallback, exitCallback, options }], IntersectionObserver } }
+// WeakMap { root || viewportDescriptor : { elements: [{ element, enterCallback, exitCallback, observerOptions }], IntersectionObserver } }
 let DOMRef = new WeakMap();
 
 /**
@@ -22,36 +22,36 @@ export default class ObserverAdmin extends Service {
    * @param {Node} element
    * @param {Function} enterCallback
    * @param {Function} exitCallback
-   * @param {Object} options
+   * @param {Object} observerOptions
+   * @param {String} viewportDescriptor
    */
-  add(element, enterCallback, exitCallback, options) {
-    let { root = window } = options;
-    let { elements, intersectionObserver } = this._findRoot(root);
+  add(element, enterCallback, exitCallback, observerOptions, viewportDescriptor) {
+    let { root = window } = observerOptions;
+    // we will set the main key we store the intersectionObserver instance on either viewportDescriptor or root
+    let descriptor = viewportDescriptor || root;
+    let { elements, intersectionObserver } = this._findRoot(descriptor);
 
     if (elements && elements.length > 0) {
-      let [testElement] = elements;
-      let { options: elementOptions } = testElement;
-
-      // if same options, then we can add to existing intersection observer and return early
-      if (this._areSameOptions(options, elementOptions)) {
-        elements.push({ element, enterCallback, exitCallback, options });
+      // if same observerOptions found in another element already being observed, then we can add to existing intersection observer and return early
+      if (this._hasSimilarElement(observerOptions, elements)) {
+        elements.push({ element, enterCallback, exitCallback, observerOptions });
         intersectionObserver.observe(element);
         return;
       }
     }
 
-    let newIO = new IntersectionObserver(bind(this, this._setupOnIntersection(root)), options);
+    let newIO = new IntersectionObserver(bind(this, this._setupOnIntersection(descriptor)), observerOptions);
     newIO.observe(element);
-    DOMRef.set(root, { elements: [{ element, enterCallback, exitCallback, options }], intersectionObserver: newIO });
+    DOMRef.set(descriptor, { elements: [{ element, enterCallback, exitCallback, observerOptions }], intersectionObserver: newIO });
   }
 
   /**
    * @method unobserve
    * @param {Node} element
-   * @param {Node|window} root
+   * @param {Node|window} descriptor
    */
-  unobserve(element, root) {
-    let { intersectionObserver } = this._findRoot(root);
+  unobserve(element, descriptor) {
+    let { intersectionObserver } = this._findRoot(descriptor);
     if (intersectionObserver) {
       intersectionObserver.unobserve(element);
     }
@@ -61,22 +61,22 @@ export default class ObserverAdmin extends Service {
    * to unobserver multiple elements
    *
    * @method disconnect
-   * @param {Node|window} root
+   * @param {Node|window|String} descriptor
    */
-  disconnect(root) {
-    let { intersectionObserver } = this._findRoot(root);
+  disconnect(descriptor) {
+    let { intersectionObserver } = this._findRoot(descriptor);
     if (intersectionObserver) {
       intersectionObserver.disconnect();
     }
   }
 
-  _setupOnIntersection(root) {
+  _setupOnIntersection(descriptor) {
     return function(entries) {
-      return this._onAdminIntersection(root, entries);
+      return this._onAdminIntersection(descriptor, entries);
     }
   }
 
-  _onAdminIntersection(root, ioEntries) {
+  _onAdminIntersection(descriptor, ioEntries) {
     ioEntries.forEach((entry) => {
 
       let { isIntersecting, intersectionRatio } = entry;
@@ -84,7 +84,7 @@ export default class ObserverAdmin extends Service {
       // first determine if entry intersecting
       if (isIntersecting) {
         // then find entry's callback in static administration
-        let { elements = [] } = this._findRoot(root);
+        let { elements = [] } = this._findRoot(descriptor);
 
         elements.some(({ element, enterCallback }) => {
           if (element === entry.target) {
@@ -95,7 +95,7 @@ export default class ObserverAdmin extends Service {
         });
       } else if (intersectionRatio <= 0) { // exiting viewport
         // then find entry's callback in static administration
-        let { elements = [] } = this._findRoot(root);
+        let { elements = [] } = this._findRoot(descriptor);
 
         elements.some(({ element, exitCallback }) => {
           if (element === entry.target) {
@@ -109,34 +109,45 @@ export default class ObserverAdmin extends Service {
   }
 
   /**
+   * find element's root || viewportDescriptor in administrator
    * @method _findRoot
    */
-  _findRoot(root) {
-    return DOMRef.get(root) || {};
+  _findRoot(descriptor) {
+    return DOMRef.get(descriptor) || {};
   }
 
   /**
-   * We need to test this because two elements may be using the same `root` but have different options
+   * determine if existing elements for a given `root` || viewportDescriptor have the same observerOptions
+   * @method _hasSimilarElement
+   */
+  _hasSimilarElement(observerOptions, elements) {
+    return elements.some((testElement) => {
+      return this._compareOptions(observerOptions, testElement.observerOptions);
+    });
+  }
+
+  /**
+   * We need to test this because two elements may be using the same `root` but have different observerOptions
    * i.e. viewportTolerance bottom 500px vs bottom 0px
    * We only compare primitive types and objects; not arrays or functions
    *
-   * @method _areSameOptions
+   * @method _compareOptions
    */
-  _areSameOptions(options, elementOptions) {
+  _compareOptions(observerOptions, elementOptions) {
     // simple comparison of string, number or even null/undefined
-    let type1 = Object.prototype.toString.call(options);
+    let type1 = Object.prototype.toString.call(observerOptions);
     let type2 = Object.prototype.toString.call(elementOptions);
     if (type1 !== type2) {
       return false;
     } else if (type1 !== '[object Object]' && type2 !== '[object Object]') {
-      return options === elementOptions;
+      return observerOptions === elementOptions;
     }
 
     // complex comparison for only type of [object Object]
-    for (let key in options) {
-      if (options.hasOwnProperty(key)) {
+    for (let key in observerOptions) {
+      if (observerOptions.hasOwnProperty(key)) {
         // recursion to check nested
-        if (this._areSameOptions(options[key], elementOptions[key]) === false) {
+        if (this._compareOptions(observerOptions[key], elementOptions[key]) === false) {
           return false;
         }
       }

--- a/tests/dummy/app/components/my-component.js
+++ b/tests/dummy/app/components/my-component.js
@@ -12,6 +12,7 @@ export default Component.extend(InViewportMixin, {
     let options = {};
 
     let {
+      viewportDescriptorOverride,
       viewportSpyOverride,
       viewportEnabledOverride,
       viewportIntersectionObserverOverride,
@@ -20,6 +21,7 @@ export default Component.extend(InViewportMixin, {
       scrollableAreaOverride,
       intersectionThresholdOverride,
     } = getProperties(this,
+      'viewportDescriptorOverride',
       'viewportSpyOverride',
       'viewportEnabledOverride',
       'viewportIntersectionObserverOverride',
@@ -29,6 +31,9 @@ export default Component.extend(InViewportMixin, {
       'intersectionThresholdOverride'
     );
 
+    if (viewportDescriptorOverride !== undefined) {
+      options.viewportDescriptor = viewportDescriptorOverride;
+    }
     if (viewportSpyOverride !== undefined) {
       options.viewportSpy = viewportSpyOverride;
     }

--- a/tests/dummy/app/templates/infinity-scrollable-raf.hbs
+++ b/tests/dummy/app/templates/infinity-scrollable-raf.hbs
@@ -30,6 +30,7 @@
 </ul>
 {{my-component
   class="infinity-scrollable-rAF-bottom infinity-scrollable"
+  viewportDescriptorOverride="raf"
   viewportIntersectionObserverOverride=false
   viewportToleranceOverride=viewportToleranceOverride
   infinityLoad=(action "infinityLoadOther")}}

--- a/tests/unit/services/-observer-admin-test.js
+++ b/tests/unit/services/-observer-admin-test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+
+module('Unit | Utility | -observer admin', function(hooks) {
+  setupTest(hooks);
+
+  test('can add element to static admin', function(assert) {
+    let service = this.owner.lookup('service:-observer-admin');
+
+    let cb = () => {};
+
+    let thing1 = document.createElement('div');
+    try {
+      service.add(thing1, cb, cb, {});
+      assert.ok(true);
+    } catch(e) {
+      assert.ok(false, `An error: ${e}`);
+    }
+  });
+
+  test('object compare works', function(assert) {
+    let service = this.owner.lookup('service:-observer-admin');
+
+    // primitive
+    assert.ok(service._areSameOptions(null, null));
+    assert.notOk(service._areSameOptions(null, undefined));
+    assert.ok(service._areSameOptions(1, 1));
+    assert.ok(service._areSameOptions('abc', 'abc'));
+    // object
+    assert.ok(service._areSameOptions({}, {}));
+    assert.notOk(service._areSameOptions({ a: 'ab' }, {}));
+    assert.ok(service._areSameOptions({ a: 'ab' }, { a: 'ab' }));
+    assert.notOk(service._areSameOptions({ a: 'ab' }, { a: 'abc' }));
+    // nested
+    assert.notOk(service._areSameOptions({ a: { b: 'cd' }}, { a: 'abc' }));
+    assert.ok(service._areSameOptions({ a: { b: 'cd' }}, { a: { b: 'cd' }}));
+    assert.notOk(service._areSameOptions({ a: { b: { c: 'de' }}}, { a: { b: 'cd' }}));
+    assert.ok(service._areSameOptions({ a: { b: { c: 'de' }}}, { a: { b: { c: 'de' }}}));
+  });
+});

--- a/tests/unit/services/-observer-admin-test.js
+++ b/tests/unit/services/-observer-admin-test.js
@@ -18,24 +18,4 @@ module('Unit | Utility | -observer admin', function(hooks) {
       assert.ok(false, `An error: ${e}`);
     }
   });
-
-  test('object compare works', function(assert) {
-    let service = this.owner.lookup('service:-observer-admin');
-
-    // primitive
-    assert.ok(service._compareOptions(null, null));
-    assert.notOk(service._compareOptions(null, undefined));
-    assert.ok(service._compareOptions(1, 1));
-    assert.ok(service._compareOptions('abc', 'abc'));
-    // object
-    assert.ok(service._compareOptions({}, {}));
-    assert.notOk(service._compareOptions({ a: 'ab' }, {}));
-    assert.ok(service._compareOptions({ a: 'ab' }, { a: 'ab' }));
-    assert.notOk(service._compareOptions({ a: 'ab' }, { a: 'abc' }));
-    // nested
-    assert.notOk(service._compareOptions({ a: { b: 'cd' }}, { a: 'abc' }));
-    assert.ok(service._compareOptions({ a: { b: 'cd' }}, { a: { b: 'cd' }}));
-    assert.notOk(service._compareOptions({ a: { b: { c: 'de' }}}, { a: { b: 'cd' }}));
-    assert.ok(service._compareOptions({ a: { b: { c: 'de' }}}, { a: { b: { c: 'de' }}}));
-  });
 });

--- a/tests/unit/services/-observer-admin-test.js
+++ b/tests/unit/services/-observer-admin-test.js
@@ -23,19 +23,19 @@ module('Unit | Utility | -observer admin', function(hooks) {
     let service = this.owner.lookup('service:-observer-admin');
 
     // primitive
-    assert.ok(service._areSameOptions(null, null));
-    assert.notOk(service._areSameOptions(null, undefined));
-    assert.ok(service._areSameOptions(1, 1));
-    assert.ok(service._areSameOptions('abc', 'abc'));
+    assert.ok(service._compareOptions(null, null));
+    assert.notOk(service._compareOptions(null, undefined));
+    assert.ok(service._compareOptions(1, 1));
+    assert.ok(service._compareOptions('abc', 'abc'));
     // object
-    assert.ok(service._areSameOptions({}, {}));
-    assert.notOk(service._areSameOptions({ a: 'ab' }, {}));
-    assert.ok(service._areSameOptions({ a: 'ab' }, { a: 'ab' }));
-    assert.notOk(service._areSameOptions({ a: 'ab' }, { a: 'abc' }));
+    assert.ok(service._compareOptions({}, {}));
+    assert.notOk(service._compareOptions({ a: 'ab' }, {}));
+    assert.ok(service._compareOptions({ a: 'ab' }, { a: 'ab' }));
+    assert.notOk(service._compareOptions({ a: 'ab' }, { a: 'abc' }));
     // nested
-    assert.notOk(service._areSameOptions({ a: { b: 'cd' }}, { a: 'abc' }));
-    assert.ok(service._areSameOptions({ a: { b: 'cd' }}, { a: { b: 'cd' }}));
-    assert.notOk(service._areSameOptions({ a: { b: { c: 'de' }}}, { a: { b: 'cd' }}));
-    assert.ok(service._areSameOptions({ a: { b: { c: 'de' }}}, { a: { b: { c: 'de' }}}));
+    assert.notOk(service._compareOptions({ a: { b: 'cd' }}, { a: 'abc' }));
+    assert.ok(service._compareOptions({ a: { b: 'cd' }}, { a: { b: 'cd' }}));
+    assert.notOk(service._compareOptions({ a: { b: { c: 'de' }}}, { a: { b: 'cd' }}));
+    assert.ok(service._compareOptions({ a: { b: { c: 'de' }}}, { a: { b: { c: 'de' }}}));
   });
 });


### PR DESCRIPTION
One current issue is that the static administrator for IntersectionObservers only creates a new one if the element that is observing uses a different `root`.  However, you could have two elements on the same page using the same `root` but have different options - `viewportTolerance`, etc.

This PR just ensures we reuse `IntersectionObserver` iff they use the same root and if they have the same `options`.