### PR TITLE
Allow `root` on static admin to have multiple keys

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -149,11 +149,11 @@ export default Mixin.create({
     // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
     // IntersectionObserver takes either a Document Element or null for `root`
     const { top = 0, left = 0, bottom = 0, right = 0 } = this.viewportTolerance;
-    this._observerOptions = {
+    set(this, '_observerOptions', {
       root: scrollableArea,
       rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
       threshold: get(this, 'intersectionThreshold')
-    };
+    });
 
     get(this, '_observerAdmin').add(element, bind(this, this._onEnterIntersection), bind(this, this._onExitIntersection), this._observerOptions);
   },
@@ -354,8 +354,8 @@ export default Mixin.create({
     set(this, '_stopListening', true);
 
     // if IntersectionObserver
-    if (get(this, 'viewportUseIntersectionObserver')) {
-      get(this, '_observerAdmin').unobserve(this.element, get(this, '_observerOptions.root'));
+    if (get(this, 'viewportUseIntersectionObserver') && get(this, 'viewportEnabled')) {
+      get(this, '_observerAdmin').unobserve(this.element, get(this, '_observerOptions'));
     }
 
     // if rAF

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -60,12 +60,9 @@ export default class ObserverAdmin extends Service {
    * @param {Node|window} root
    */
   unobserve(element, observerOptions) {
-    let elements = this._findMatchingRootEntry(observerOptions);
+    let { intersectionObserver } = this._findMatchingRootEntry(observerOptions);
 
-    if (elements.length > 0) {
-      let { intersectionObserver } = elements[0];
-      intersectionObserver.unobserve(element);
-    }
+    intersectionObserver.unobserve(element);
   }
 
   /**

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -168,46 +168,33 @@ export default class ObserverAdmin extends Service {
    */
   _determineMatchingElements(observerOptions, potentialRootMatch = {}) {
     let matchingKey = Object.keys(potentialRootMatch).filter((key) => {
-      return this._hasSimilarElement(observerOptions, potentialRootMatch[key]);
+      let { observerOptions: comparableOptions } = potentialRootMatch[key];
+      return this._compareOptions(observerOptions, comparableOptions);
     });
     return potentialRootMatch[matchingKey];
   }
 
   /**
-   * determine if share same observerOptions as to be observed element's observerOptions
-   *
-   * @method _hasSimilarElement
-   * @param {Object} observerOptions
-   * @param {Array} elements
-   * @return {Array}
-   */
-  _hasSimilarElement(observerOptions, { elements = [] }) {
-    return elements.some((testElement) => {
-      return this._compareOptions(observerOptions, testElement.observerOptions);
-    });
-  }
-
-  /**
    * @method _compareOptions
    * @param {Object} observerOptions
-   * @param {Object} elementOptions
+   * @param {Object} comparableOptions
    * @return {Boolean}
    */
-  _compareOptions(observerOptions, elementOptions) {
+  _compareOptions(observerOptions, comparableOptions) {
     // simple comparison of string, number or even null/undefined
     let type1 = Object.prototype.toString.call(observerOptions);
-    let type2 = Object.prototype.toString.call(elementOptions);
+    let type2 = Object.prototype.toString.call(comparableOptions);
     if (type1 !== type2) {
       return false;
     } else if (type1 !== '[object Object]' && type2 !== '[object Object]') {
-      return observerOptions === elementOptions;
+      return observerOptions === comparableOptions;
     }
 
     // complex comparison for only type of [object Object]
     for (let key in observerOptions) {
       if (observerOptions.hasOwnProperty(key)) {
         // recursion to check nested
-        if (this._compareOptions(observerOptions[key], elementOptions[key]) === false) {
+        if (this._compareOptions(observerOptions[key], comparableOptions[key]) === false) {
           return false;
         }
       }

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -6,11 +6,10 @@ import { bind } from '@ember/runloop';
 const DOMRef = new WeakMap();
 
 /**
- * Static administrator to ensure use one IntersectionObserver per viewport
+ * Static administrator to ensure use one IntersectionObserver per combination of root + observerOptions
  * Use `root` (viewport) as lookup property
- * `root` will have one IntersectionObserver with many entries (elements) to watch
- * provided callback will ensure consumer of this service is able to react to enter or exit
- * of intersection observer
+ * `root` will have many options with each option containing one IntersectionObserver instance and various callbacks
+ * Provided callback will ensure consumer of this service is able to react to enter or exit of intersection observer
  *
  * @module Ember.Service
  * @class ObserverAdmin
@@ -129,7 +128,7 @@ export default class ObserverAdmin extends Service {
 
   /**
    * @method _findRoot
-   * @param {Node} root
+   * @param {Node|window} root
    * @return {Object} of elements that share same root
    */
   _findRoot(root) {
@@ -138,9 +137,9 @@ export default class ObserverAdmin extends Service {
 
   /**
    * Used for onIntersection callbacks and unobserving the IntersectionObserver
-   * We don't care about key order in the observerOptions because we already added
+   * We don't care about observerOptions key order because we already added
    * to the static administrator or found an existing IntersectionObserver with the same
-   * root && observerOptions to reuse their IntersectionObserver
+   * root && observerOptions to reuse
    *
    * @method _findMatchingRootEntry
    * @param {Object} observerOptions
@@ -154,8 +153,8 @@ export default class ObserverAdmin extends Service {
   }
 
   /**
-   * determine if existing elements for a given root based on passed in observerOptions
-   * irregardless of sort order of keys
+   * Determine if existing elements for a given root based on passed in observerOptions
+   * regardless of sort order of keys
    *
    * @method _determineMatchingElements
    * @param {Object} observerOptions
@@ -172,6 +171,9 @@ export default class ObserverAdmin extends Service {
   }
 
   /**
+   * recursive method to test primitive string, number, null, etc and complex
+   * object equality.
+   *
    * @method _areOptionsSame
    * @param {Object} observerOptions
    * @param {Object} comparableOptions

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -40,6 +40,7 @@ export default class ObserverAdmin extends Service {
       return;
     }
 
+    // No matching entry for root in static admin, thus create new IntersectionObserver instance
     let newIO = new IntersectionObserver(bind(this, this._setupOnIntersection(observerOptions)), observerOptions);
     newIO.observe(element);
     let observerEntry = {elements: [element], enterCallback, exitCallback, observerOptions, intersectionObserver: newIO };
@@ -171,6 +172,7 @@ export default class ObserverAdmin extends Service {
       let { observerOptions: comparableOptions } = potentialRootMatch[key];
       return this._areOptionsSame(observerOptions, comparableOptions);
     })[0];
+
     return potentialRootMatch[matchingKey];
   }
 

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -163,7 +163,7 @@ export default class ObserverAdmin extends Service {
    *
    * @method _determineMatchingElements
    * @param {Object} observerOptions
-   * @param {Object} potentialRootMatch e.g. { stringifiedOptions: [], stringifiedOptions: [], ...}
+   * @param {Object} potentialRootMatch e.g. { stringifiedOptions: { elements: [], ... }, stringifiedOptions: { elements: [], ... }}
    * @return {Object} containing array of elements and other meta
    */
   _determineMatchingElements(observerOptions, potentialRootMatch = {}) {

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -169,18 +169,18 @@ export default class ObserverAdmin extends Service {
   _determineMatchingElements(observerOptions, potentialRootMatch = {}) {
     let matchingKey = Object.keys(potentialRootMatch).filter((key) => {
       let { observerOptions: comparableOptions } = potentialRootMatch[key];
-      return this._compareOptions(observerOptions, comparableOptions);
+      return this._areOptionsSame(observerOptions, comparableOptions);
     });
     return potentialRootMatch[matchingKey];
   }
 
   /**
-   * @method _compareOptions
+   * @method _areOptionsSame
    * @param {Object} observerOptions
    * @param {Object} comparableOptions
    * @return {Boolean}
    */
-  _compareOptions(observerOptions, comparableOptions) {
+  _areOptionsSame(observerOptions, comparableOptions) {
     // simple comparison of string, number or even null/undefined
     let type1 = Object.prototype.toString.call(observerOptions);
     let type2 = Object.prototype.toString.call(comparableOptions);
@@ -194,7 +194,7 @@ export default class ObserverAdmin extends Service {
     for (let key in observerOptions) {
       if (observerOptions.hasOwnProperty(key)) {
         // recursion to check nested
-        if (this._compareOptions(observerOptions[key], comparableOptions[key]) === false) {
+        if (this._areOptionsSame(observerOptions[key], comparableOptions[key]) === false) {
           return false;
         }
       }

--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -170,7 +170,7 @@ export default class ObserverAdmin extends Service {
     let matchingKey = Object.keys(potentialRootMatch).filter((key) => {
       let { observerOptions: comparableOptions } = potentialRootMatch[key];
       return this._areOptionsSame(observerOptions, comparableOptions);
-    });
+    })[0];
     return potentialRootMatch[matchingKey];
   }
 

--- a/tests/unit/services/-observer-admin-test.js
+++ b/tests/unit/services/-observer-admin-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Mixin | -observer-admin', function(hooks) {
+  setupTest(hooks);
+
+  test('_areOptionsSame works', function(assert) {
+    let service = this.owner.lookup('service:-observer-admin');
+
+    // primitive
+    assert.ok(service._areOptionsSame('a', 'a'));
+    assert.ok(service._areOptionsSame(1, 1));
+    assert.notOk(service._areOptionsSame('a', 'ab'));
+    assert.notOk(service._areOptionsSame(1, 2));
+
+    // complex
+    assert.ok(service._areOptionsSame({}, {}));
+    assert.notOk(service._areOptionsSame({ a: 'b' }, {}));
+    assert.ok(service._areOptionsSame({ a: 'b' }, { a: 'b' }));
+    assert.notOk(service._areOptionsSame({ a: { b: 'c' }}, { a: 'b' }));
+    assert.ok(service._areOptionsSame({ a: { b: 'c' }}, { a: { b: 'c' } }));
+    assert.notOk(service._areOptionsSame({ a: { b: { c: 'd' } }}, { a: { b: 'c' } }));
+    assert.ok(service._areOptionsSame({ a: { b: { c: 'd' } }}, { a: { b: { c: 'd' } } }));
+  });
+
+  test('_determineMatchingElements works', function(assert) {
+    let service = this.owner.lookup('service:-observer-admin');
+    assert.ok(service._determineMatchingElements({ a: { b: 'c' }}, { key: { observerOptions: { a: { b: 'c' } }}}));
+    assert.notOk(service._determineMatchingElements({ a: { b: 'd' }}, { key: { observerOptions: { a: { b: 'c' } }}}));
+  });
+});


### PR DESCRIPTION
The root scrollable area can have multiple elements with different observer options.  To prevent the first element's options from overriding the rest of the observers in the static administrator (cache to reuse intersection observer instances), we need to ensure that when we want to find a potential match for an element, that we compare the to be added element's observer options and only reuse the instance of the IntersectionObserver iff the element shares the same root and same observer options