### PR TITLE
 Do not cancel rAF as this effects other elements that are observed

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -365,7 +365,6 @@ export default Mixin.create({
       next(this, () => {
         let _rAFAdmin = get(this, '_rAFAdmin');
         _rAFAdmin.remove(elementId);
-        _rAFAdmin.cancel();
         delete rAFIDS[elementId];
       });
     }

--- a/addon/services/-raf-admin.js
+++ b/addon/services/-raf-admin.js
@@ -10,7 +10,6 @@ export default class RAFAdmin extends Service {
   init(...args) {
     super.init(...args);
     this.pool = [];
-    this.isRunning = true;
     this.flush();
   }
 
@@ -24,9 +23,7 @@ export default class RAFAdmin extends Service {
         item[Object.keys(item)[0]]();
       });
 
-      if (this.isRunning) {
-        this.flush();
-      }
+      this.flush();
     });
   }
 

--- a/addon/services/-raf-admin.js
+++ b/addon/services/-raf-admin.js
@@ -42,8 +42,4 @@ export default class RAFAdmin extends Service {
   reset() {
     this.pool = [];
   }
-
-  cancel() {
-    this.isRunning = false;
-  }
 }


### PR DESCRIPTION
If there are many elements on the page, rAF `cancel` effects other observed elements.  This was just a minor optimization but the downsides of this outweigh those benefits.

Reverting for now but need to revisit.

Ref #145 #152 

close #154 