### PR TITLE
Handle `root` element gaining custom properties

### DIFF
--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -62,10 +62,10 @@ export default class ObserverAdmin extends Service {
 
     if (potentialRootMatch) {
       // if share same root and need to add new entry to root match
-      potentialRootMatch[JSON.stringify(observerOptions)] = observerEntry;
+      potentialRootMatch[this._stringifyObserverOptions(observerOptions)] = observerEntry;
     } else {
       // no root exists, so add to WeakMap
-      this._DOMRef.set(root, { [JSON.stringify(observerOptions)]: observerEntry });
+      this._DOMRef.set(root, { [this._stringifyObserverOptions(observerOptions)]: observerEntry });
     }
   }
 
@@ -164,7 +164,7 @@ export default class ObserverAdmin extends Service {
    * @return {Object} entry with elements and other options
    */
   _findMatchingRootEntry(observerOptions) {
-    let stringifiedOptions = JSON.stringify(observerOptions);
+    let stringifiedOptions = this._stringifyObserverOptions(observerOptions);
     let { root = window } = observerOptions;
     let matchingRoot = this._findRoot(root) || {};
     return matchingRoot[stringifiedOptions];
@@ -219,5 +219,22 @@ export default class ObserverAdmin extends Service {
       }
     }
     return true;
+  }
+
+  /**
+   * Stringify observerOptions for use as a key.
+   * Excludes observerOptions.root so that the resulting key is stable
+   *
+   * @param {Object} observerOptions
+   * @private
+   * @return {String}
+   */
+  _stringifyObserverOptions(observerOptions) {
+    let replacer = (key, value) => {
+      if (key === 'root') return undefined;
+      return value;
+    };
+
+    return JSON.stringify(observerOptions, replacer);
   }
 }

--- a/tests/unit/services/-observer-admin-test.js
+++ b/tests/unit/services/-observer-admin-test.js
@@ -4,6 +4,24 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Mixin | -observer-admin', function(hooks) {
   setupTest(hooks);
 
+  // https://github.com/DockYard/ember-in-viewport/issues/160
+  test('handles root element gaining custom properties', function(assert) {
+    let service = this.owner.lookup('service:-observer-admin');
+    let root = document.createElement('div');
+    let observerOptions = {root, rootMargin: '0px 0px 100px 0px', threshold: 0};
+
+    service.add(root, () => {}, () => {}, observerOptions);
+
+    // sense check
+    assert.ok(service._findMatchingRootEntry(observerOptions));
+
+    // simulate jQuery adding a sizzle1234 type property to root HtmlElement
+    root.sizzle1234 = {test: true};
+
+    // failing test for #160
+    assert.ok(service._findMatchingRootEntry(observerOptions));
+  })
+
   test('_areOptionsSame works', function(assert) {
     let service = this.owner.lookup('service:-observer-admin');
 


### PR DESCRIPTION
closes https://github.com/DockYard/ember-in-viewport/issues/160
- `JSON.stringify({root: HtmlElement})` does not generate a stable key because HtmlElements can gain custom properties such as when jQuery adds sizzle cache properties
- adds `-observer-admin._stringifyObserverOptions()` that strips the `root` property when stringifying so that the key is stable