### PR TITLE
Fix calculation of viewport width

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -173,7 +173,7 @@ export default Mixin.create({
     }
 
     const height = scrollableArea ? scrollableArea.offsetHeight + scrollableArea.getBoundingClientRect().top : window.innerHeight;
-    const width = scrollableArea ? scrollableArea.offsetWidth : window.innerWidth;
+    const width = scrollableArea ? scrollableArea.offsetWidth + scrollableArea.getBoundingClientRect().left : window.innerWidth;
     const boundingClientRect = element.getBoundingClientRect();
 
     if (boundingClientRect) {


### PR DESCRIPTION
<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes #165  .

## Context 
I'm using this as a dependency of one project I'm currently working on and realized that was a bug with a specific use case demonstrared below:

![screen shot 2018-10-11 at 16 19 07](https://user-images.githubusercontent.com/12813036/46814821-730c8900-cd71-11e8-8883-49f45d7ad1e1.png)

Basically the element is considered outside of the viewport even if it's inside of it, as you can see. I checked the issues and solution provided in #165 solved the problem, so I decided to make a PR. 

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->
Make the scrollable area width calculation correct
