### PR TITLE
Fix scope memory leak

### DIFF
--- a/addon/services/-observer-admin.js
+++ b/addon/services/-observer-admin.js
@@ -95,6 +95,15 @@ export default class ObserverAdmin extends Service {
   }
 
   /**
+   * @method willDestroy
+   * @public
+   */
+  willDestroy() {
+    this._super(...arguments);
+    this._DOMRef = null;
+  }
+
+  /**
    * use function composition to curry observerOptions
    *
    * @method _setupOnIntersection


### PR DESCRIPTION
I'm seeing some memory leaks due to retained object in our intersection observer administrator.

The use of `window` as a key is causing memory to be retained between each test run.