### PR TITLE
Ensure rAF takes into account sentinels w and h

### DIFF
--- a/addon/utils/is-in-viewport.js
+++ b/addon/utils/is-in-viewport.js
@@ -8,7 +8,7 @@ const defaultTolerance = {
 };
 
 export default function isInViewport(boundingClientRect = {}, height = 0, width = 0, tolerance = defaultTolerance) {
-  const { top, left, bottom, right } = boundingClientRect;
+  const { top, left, bottom, right, height: h, width: w } = boundingClientRect;
   const tolerances = assign(assign({}, defaultTolerance), tolerance);
   const {
     top: topTolerance,
@@ -20,7 +20,7 @@ export default function isInViewport(boundingClientRect = {}, height = 0, width 
   return (
     (top + topTolerance)       >= 0 &&
     (left + leftTolerance)     >= 0 &&
-    (Math.round(bottom) - bottomTolerance) <= Math.round(height) &&
-    (Math.round(right) - rightTolerance)   <= Math.round(width)
+    (Math.round(bottom) - bottomTolerance - h) <= Math.round(height) &&
+    (Math.round(right) - rightTolerance - w)   <= Math.round(width)
   );
 }

--- a/tests/unit/utils/is-in-viewport-test.js
+++ b/tests/unit/utils/is-in-viewport-test.js
@@ -12,14 +12,18 @@ module('Unit | Utility | is in viewport', function(hooks) {
       top: 450,
       left: 150,
       bottom: 550,
-      right: 1130
+      right: 1130,
+      height: 1,
+      width: 1
     };
 
     fakeRectInViewport = {
       top: 300,
       left: 150,
       bottom: 400,
-      right: 1130
+      right: 1130,
+      height: 1,
+      width: 1
     };
 
     fakeWindow = {
@@ -65,7 +69,9 @@ module('Unit | Utility | is in viewport', function(hooks) {
       top: 300,
       left: 150,
       bottom: 400.4,
-      right: 1130
+      right: 1130,
+      height: 1,
+      width: 1
     };
     const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
     assert.ok(result);
@@ -78,7 +84,9 @@ module('Unit | Utility | is in viewport', function(hooks) {
       top: 300,
       left: 150,
       bottom: 400,
-      right: 1280.4
+      right: 1280.4,
+      height: 1,
+      width: 1
     };
     const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
     assert.ok(result);
@@ -91,7 +99,9 @@ module('Unit | Utility | is in viewport', function(hooks) {
       top: 300,
       left: 150,
       bottom: 400.8,
-      right: 1130
+      right: 1130,
+      height: 0,
+      width: 0
     };
     const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
     assert.notOk(result);
@@ -104,7 +114,9 @@ module('Unit | Utility | is in viewport', function(hooks) {
       top: 300,
       left: 150,
       bottom: 400,
-      right: 1280.7
+      right: 1280.7,
+      height: 0,
+      width: 0
     };
     const result = isInViewport(fakeRectWithSubpixelsInViewport, innerHeight, innerWidth, fakeNoTolerance);
     assert.notOk(result);


### PR DESCRIPTION
Right now, the w and height of the sentinel are not taken into account when determining if it is in viewport or not.  As a result, it only triggers the relevant actions when the whole element is in viewport.