### PR TITLE
Just a small town boy living in a ember modifier world

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ Using with [Modifiers](https://blog.emberjs.com/2019/03/06/coming-soon-in-ember-
 1.  Install [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers)
 2.  Use the `did-insert` hook inside a component
 3.  Wire up the component like so
+
+Note - This is in lieu of a `did-enter-viewport` modifier, which we plan on adding in the future.  Compared to the solution below, `did-enter-viewport` won't need a container (`this`) passed to it.  But for now, to start using modifiers, this is the easy path.
+
 ```js
 import Component from '@ember/component';
 import { set } from '@ember/object';
@@ -253,6 +256,7 @@ export default Component.extend(InViewportMixin, {
   },
 
   didEnterViewport() {
+    // this will only work with one element being watched in the container. This is still a TODO to enable
     this.infinityLoad();
   }
 });

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This `ember-cli` addon adds a simple, highly performant Ember Mixin to your app.
 
 ## Demo or examples
 - Dummy app (`ember serve`): https://github.com/DockYard/ember-in-viewport/tree/master/tests/dummy
+- Use with Ember [Modifiers](#modifiers) and [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers)
 - [ember-infinity](https://github.com/ember-infinity/ember-infinity)
 - [ember-light-table](https://github.com/offirgolan/ember-light-table)
 - Tracking advertisement impressions
@@ -220,6 +221,49 @@ module.exports = function(environment) {
 
 Note if you want to disable right and left in-viewport triggers, set these values to `Infinity`.
 ```
+
+### Modifiers
+
+Using with [Modifiers](https://blog.emberjs.com/2019/03/06/coming-soon-in-ember-octane-part-4.html) is easy.
+
+1.  Install [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers)
+2.  Use the `did-insert` hook inside a component
+3.  Wire up the component like so
+```js
+import Component from '@ember/component';
+import { set } from '@ember/object';
+import InViewportMixin from 'ember-in-viewport';
+
+export default Component.extend(InViewportMixin, {
+  tagName: '',
+
+  // if you do have a tagName ^^, then you can use `didInsertElement` or no-op it.  You choose
+  // didInsertElement() {},
+  didInsertNode(element, [instance]) {
+    instance.watchElement(element);
+  },
+
+  init() {
+    this._super(...arguments);
+
+    set(this, 'viewportSpy', true);
+    set(this, 'viewportTolerance', {
+      bottom: 300
+    });
+  },
+
+  didEnterViewport() {
+    this.infinityLoad();
+  }
+});
+```
+
+```hbs
+<div {{did-insert this.didInsertNode this}}>
+  {{yield}}
+</div>
+```
+
 ## [**IntersectionObserver**'s Browser Support](https://platform-status.mozilla.org/)
 
 ### Out of the box

--- a/package-lock.json
+++ b/package-lock.json
@@ -5211,6 +5211,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz",
       "integrity": "sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==",
+      "dev": true,
       "requires": {
         "babel-plugin-debug-macros": "^0.2.0",
         "ember-cli-version-checker": "^2.1.1",
@@ -5532,6 +5533,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.0.3.tgz",
       "integrity": "sha512-d8Uz0BhAZaqzttF4NXTwJ/A8uPrgd7fMho5jh89BfzJAHu5WZfGewX9cbjh3m6f512ZyxkIeeolw3Z5/Jyaujg==",
+      "dev": true,
       "requires": {
         "ember-cli-babel": "^7.4.2",
         "ember-cli-version-checker": "^2.1.2",
@@ -8350,9 +8352,9 @@
       }
     },
     "intersection-observer-admin": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/intersection-observer-admin/-/intersection-observer-admin-0.0.5.tgz",
-      "integrity": "sha512-Nhrd3lQM0j7w6EKup+i67e39hy8IK/xPjo+g+9Ec/3F6qsd+9wGPN7Uemc/J5scVXeBEP4SEgxOYGGncc4RrWA=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer-admin/-/intersection-observer-admin-0.1.0.tgz",
+      "integrity": "sha512-5ZG7AVBojgngckA4B7rzr6S751yxIjiolmj08y5KBgu1Xe8fAmO2hWonYzbi6jwXNtdqAMld8jAZGxZS2KDjKQ=="
     },
     "into-stream": {
       "version": "3.1.0",
@@ -10816,9 +10818,9 @@
       }
     },
     "raf-pool": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/raf-pool/-/raf-pool-0.0.4.tgz",
-      "integrity": "sha512-b0OhSuUxyGvvDrPPhUrCjxtayAR2yZxyleifiOT5qgxHB4pcnMPZRxgeo1S7tJ8HfQnVlR4/3d9QRNvCPcaA8g=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/raf-pool/-/raf-pool-0.1.0.tgz",
+      "integrity": "sha512-TU79Jf8D0OsPlEPegLmx4O/Az3I2qm3TZnHEZE+fUJ/aeVf46m/HDRV5lHrdRQ9m3PhodfwFVwmMz/BgUXEppg=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -869,6 +869,16 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "@ember/render-modifiers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.0.tgz",
+      "integrity": "sha512-TqUW7exzLUwnzqHqKbo5ui0rvrS/YkbRlFD+h07kDYVFJkS2uPwkQE/K4YDeTywqN6er7VamFwl7Og98sPjmiQ==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-modifier-manager-polyfill": "^1.0.1"
+      }
+    },
     "@ember/test-helpers": {
       "version": "0.7.27",
       "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-0.7.27.tgz",
@@ -5197,6 +5207,16 @@
         "semver": "^5.3.0"
       }
     },
+    "ember-compatibility-helpers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz",
+      "integrity": "sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==",
+      "requires": {
+        "babel-plugin-debug-macros": "^0.2.0",
+        "ember-cli-version-checker": "^2.1.1",
+        "semver": "^5.4.1"
+      }
+    },
     "ember-disable-prototype-extensions": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz",
@@ -5506,6 +5526,16 @@
           "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
           "dev": true
         }
+      }
+    },
+    "ember-modifier-manager-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.0.3.tgz",
+      "integrity": "sha512-d8Uz0BhAZaqzttF4NXTwJ/A8uPrgd7fMho5jh89BfzJAHu5WZfGewX9cbjh3m6f512ZyxkIeeolw3Z5/Jyaujg==",
+      "requires": {
+        "ember-cli-babel": "^7.4.2",
+        "ember-cli-version-checker": "^2.1.2",
+        "ember-compatibility-helpers": "^1.2.0"
       }
     },
     "ember-qunit": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "@ember/render-modifiers": "^1.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.8.1",
     "ember-cli-dependency-checker": "^3.1.0",
@@ -35,7 +36,6 @@
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^2.0.0",
     "ember-cli-inject-live-reload": "^2.0.1",
-    "ember-qunit": "^3.4.1",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.1.0",
@@ -43,6 +43,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-qunit": "^3.4.1",
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.8.0",
     "ember-source-channel-url": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "dependencies": {
     "ember-auto-import": "^1.2.15",
     "ember-cli-babel": "^7.1.2",
-    "intersection-observer-admin": "0.0.5",
-    "raf-pool": "0.0.4"
+    "intersection-observer-admin": "0.1.0",
+    "raf-pool": "0.1.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/tests/dummy/app/components/my-modifier.js
+++ b/tests/dummy/app/components/my-modifier.js
@@ -5,6 +5,8 @@ import InViewportMixin from 'ember-in-viewport';
 export default Component.extend(InViewportMixin, {
   tagName: '',
 
+  // if you do have a tagName ^^, then you can use `didInsertElement` or no-op it
+  // didInsertElement() {},
   didInsertNode(element, [instance]) {
     instance.watchElement(element);
   },

--- a/tests/dummy/app/components/my-modifier.js
+++ b/tests/dummy/app/components/my-modifier.js
@@ -1,0 +1,24 @@
+import Component from '@ember/component';
+import { set } from '@ember/object';
+import InViewportMixin from 'ember-in-viewport';
+
+export default Component.extend(InViewportMixin, {
+  tagName: '',
+
+  didInsertNode(element, [instance]) {
+    instance.watchElement(element);
+  },
+
+  init() {
+    this._super(...arguments);
+
+    set(this, 'viewportSpy', true);
+    set(this, 'viewportTolerance', {
+      bottom: 300
+    });
+  },
+
+  didEnterViewport() {
+    this.infinityLoad();
+  }
+});

--- a/tests/dummy/app/controllers/infinity-modifier.js
+++ b/tests/dummy/app/controllers/infinity-modifier.js
@@ -1,0 +1,28 @@
+import Controller from '@ember/controller';
+import { set, get } from '@ember/object';
+import { later } from '@ember/runloop';
+import { Promise } from 'rsvp';
+
+const images = ["jarjan", "aio___", "kushsolitary", "kolage", "idiot", "gt"];
+
+const arr = Array.apply(null, Array(10));
+const models = [...arr.map(() => `https://s3.amazonaws.com/uifaces/faces/twitter/${images[(Math.random() * images.length) | 0]}/128.jpg`)];
+
+export default Controller.extend({
+  models,
+
+  actions: {
+    infinityLoad() {
+      const arr = Array.apply(null, Array(10));
+      const newModels = [...arr.map(() => `https://s3.amazonaws.com/uifaces/faces/twitter/${images[(Math.random() * images.length) | 0]}/128.jpg`)];
+      return new Promise((resolve) => {
+        later(() => {
+          const models = get(this, 'models');
+          models.push(...newModels);
+          set(this, 'models', Array.prototype.slice.call(models));
+          resolve();
+        }, 0);
+      });
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,7 @@ const Router = EmberRouter.extend({
 
 Router.map(function() {
   this.route('infinity');
+  this.route('infinity-modifier');
   this.route('infinity-scrollable');
   this.route('infinity-scrollable-raf');
   this.route('infinity-scrollable-scrollevent');

--- a/tests/dummy/app/routes/infinity-modifier.js
+++ b/tests/dummy/app/routes/infinity-modifier.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,6 +2,7 @@
 
 <ul>
   <li>{{link-to "Infinity IntersectionObserver" "infinity"}}</li>
+  <li>{{link-to "Infinity with a Modifier" "infinity-modifier"}}</li>
   <li>{{link-to "Infinity Scrollable IntersectionObserver" "infinity-scrollable"}}</li>
   <li>{{link-to "Infinity Scrollable rAF" "infinity-scrollable-raf"}}</li>
   <li>{{link-to "Infinity Scrollable Event" "infinity-scrollable-scrollevent"}}</li>

--- a/tests/dummy/app/templates/components/my-modifier.hbs
+++ b/tests/dummy/app/templates/components/my-modifier.hbs
@@ -1,0 +1,3 @@
+<div {{did-insert this.didInsertNode this}}>
+  {{yield}}
+</div>

--- a/tests/dummy/app/templates/infinity-modifier.hbs
+++ b/tests/dummy/app/templates/infinity-modifier.hbs
@@ -1,0 +1,6 @@
+<ul>
+  {{#each models as |val|}}
+    <li><img src={{val}} /></li>
+  {{/each}}
+</ul>
+{{my-modifier infinityLoad=(action "infinityLoad")}}


### PR DESCRIPTION
This is not the final product, but the start of how one could use a modifier inside a component. 
 No feature added.  Required a slight refactor to the mixin but seems like the easiest path for now if people want to use an element modifier inside a component (w/ or w/o a tagName btw!)

In the example in the dummy app, it uses `did-insert` from [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers) and adds the specific element to the pool of elements that we watch.  

You could possibly use this to watch multiple nodes.

```js
export default Component.extend(InViewportMixin, {
  didInsertHeader() {}
  didInsertFooter() {}
  didInsertHeroImage() {}
});
```
although for this to work with multiple items, we would need to figure out what to do when triggering `didEnterViewport`

See `dummy/components/my-modifier.js` for the example.

close #109 close #177 