### PR TITLE
New API: watchElement for classes with no mixin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
     sourceType: 'module'
   },
   plugins: [

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ export default class MyClass extends Component {
 }
 ```
 
-Options as the second argument to `inViewport.watchElement` include `intersectionThreshold`, `scrollableArea` && `viewportTolerance`
+Options as the second argument to `inViewport.watchElement` include `intersectionThreshold`, `scrollableArea`, `viewportSpy` && `viewportTolerance`
 
 ## [**IntersectionObserver**'s Browser Support](https://platform-status.mozilla.org/)
 

--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ export default class MyClass extends Component {
 
   didInsertElement() {
     const loader = document.getElementById('loader');
-    this.inViewport.watchElement(loader);
-    this.inViewport.addEnterCallback(loader, this.didEnterViewport.bind(this));
+    const { onEnter, onExit } = this.inViewport.watchElement(loader);
+    onEnter(this.didEnterViewport.bind(this));
   }
 
   didEnterViewport() {
@@ -302,7 +302,8 @@ export default class MyClass extends Component {
 
   willDestroy() {
     // need to manage cache yourself if you don't use the mixin
-    this.inViewport.destroy();
+    const loader = document.getElementById('loader');
+    this.inViewport.stop(loader);
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ We utilize pooling techniques to reuse Intersection Observers and rAF observers 
 ## Demo or examples
 - Dummy app (`ember serve`): https://github.com/DockYard/ember-in-viewport/tree/master/tests/dummy
 - Use with Ember [Modifiers](#modifiers) and [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers)
+- Use with [Native Classes](#classes)
 - [ember-infinity](https://github.com/ember-infinity/ember-infinity)
 - [ember-light-table](https://github.com/offirgolan/ember-light-table)
 - Tracking advertisement impressions
@@ -274,6 +275,36 @@ export default Component.extend(InViewportMixin, {
 <div {{did-insert this.didInsertNode this}}>
   {{yield}}
 </div>
+```
+
+### Classes
+
+This allows you to absolve yourself from using a mixin in native classes!
+
+```js
+import Component from '@ember/component';
+import { tagName } from '@ember-decorators/component';
+import { inject as service } from '@ember/service'; // with polyfill
+
+@tagName('')
+export default class MyClass extends Component {
+  @service inViewport
+
+  didInsertElement() {
+    const loader = document.getElementById('loader');
+    this.inViewport.watchElement(loader);
+    this.inViewport.addEnterCallback(loader, this.didEnterViewport.bind(this));
+  }
+
+  didEnterViewport() {
+    this.infinityLoad();
+  },
+
+  willDestroy() {
+    // need to manage cache yourself if you don't use the mixin
+    this.inViewport.destroy();
+  }
+}
 ```
 
 ## [**IntersectionObserver**'s Browser Support](https://platform-status.mozilla.org/)

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ export default class MyClass extends Component {
   }
 
   didEnterViewport() {
+    // do some other stuff
     this.infinityLoad();
   },
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ export default class MyClass extends Component {
 
   didInsertElement() {
     const loader = document.getElementById('loader');
-    const { onEnter, onExit } = this.inViewport.watchElement(loader);
+    const viewportTolerance = { bottom: 200 };
+    const { onEnter, onExit } = this.inViewport.watchElement(loader, { viewportTolerance });
     onEnter(this.didEnterViewport.bind(this));
   }
 
@@ -308,6 +309,8 @@ export default class MyClass extends Component {
   }
 }
 ```
+
+Options as the second argument to `inViewport.watchElement` include `intersectionThreshold`, `scrollableArea` && `viewportTolerance`
 
 ## [**IntersectionObserver**'s Browser Support](https://platform-status.mozilla.org/)
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ export default class MyClass extends Component {
   willDestroy() {
     // need to manage cache yourself if you don't use the mixin
     const loader = document.getElementById('loader');
-    this.inViewport.stop(loader);
+    this.inViewport.stopWatching(loader);
   }
 }
 ```

--- a/addon/-private/observer-admin.js
+++ b/addon/-private/observer-admin.js
@@ -28,13 +28,21 @@ export default class ObserverAdmin {
    */
   add(element, observerOptions, enterCallback, exitCallback) {
     if (enterCallback) {
-      this.instance.addEnterCallback(element, enterCallback);
+      this.addEnterCallback(element, enterCallback);
     }
     if (exitCallback) {
-      this.instance.addExitCallback(element, exitCallback);
+      this.addExitCallback(element, exitCallback);
     }
 
     return this.instance.observe(element, observerOptions);
+  }
+
+  addEnterCallback(element, enterCallback) {
+      this.instance.addEnterCallback(element, enterCallback);
+  }
+
+  addExitCallback(element, exitCallback) {
+      this.instance.addExitCallback(element, exitCallback);
   }
 
   /**

--- a/addon/-private/raf-admin.js
+++ b/addon/-private/raf-admin.js
@@ -1,4 +1,5 @@
 import RafPool from 'raf-pool';
+import isInViewport from 'ember-in-viewport/utils/is-in-viewport';
 
 /**
  * ensure use on requestAnimationFrame, no matter how many components
@@ -10,6 +11,7 @@ export default class RAFAdmin {
   /** @private **/
   constructor() {
     this._rafPool = new RafPool();
+    this.registry = new WeakMap();
   }
 
   add(...args) {
@@ -27,4 +29,104 @@ export default class RAFAdmin {
   reset(...args) {
     this._rafPool.reset(...args);
   }
+
+  addEnterCallback(element, enterCallback) {
+    this.registry.set(
+      element,
+      Object.assign({}, this.registry.get(element), { enterCallback })
+    );
+  }
+
+  addExitCallback(element, exitCallback) {
+    this.registry.set(
+      element,
+      Object.assign({}, this.registry.get(element), { exitCallback })
+    );
+  }
+
+  getCallbacks(element) {
+    return this.registry.get(element);
+  }
+}
+
+export function startRAF(
+  element,
+  {
+    scrollableArea,
+    viewportTolerance,
+    viewportSpy = false
+  },
+  enterCallback,
+  exitCallback,
+  addRAF
+) {
+  const domScrollableArea = scrollableArea ? document.querySelector(scrollableArea) : undefined;
+
+  const height = domScrollableArea
+    ? domScrollableArea.offsetHeight + domScrollableArea.getBoundingClientRect().top
+    : window.innerHeight;
+  const width = scrollableArea
+    ? domScrollableArea.offsetWidth + domScrollableArea.getBoundingClientRect().left
+    : window.innerWidth;
+  const boundingClientRect = element.getBoundingClientRect();
+
+  if (boundingClientRect) {
+    const viewportEntered = element.getAttribute('data-in-viewport-entered');
+
+    triggerDidEnterViewport(
+      element,
+      isInViewport(
+        boundingClientRect,
+        height,
+        width,
+        viewportTolerance
+      ),
+      viewportSpy,
+      enterCallback,
+      exitCallback,
+      viewportEntered
+    );
+
+    if (viewportSpy || viewportEntered !== 'true') {
+      // recursive
+      addRAF(
+        startRAF.bind(
+          this,
+          element,
+          { scrollableArea, viewportTolerance, viewportSpy },
+          enterCallback,
+          exitCallback,
+          addRAF
+        )
+      );
+    }
+  }
+}
+
+function triggerDidEnterViewport(
+  element,
+  hasEnteredViewport,
+  viewportSpy,
+  enterCallback,
+  exitCallback,
+  viewportEntered = false
+) {
+  const didEnter = (!viewportEntered || viewportEntered === 'false') && hasEnteredViewport;
+  const didLeave = viewportEntered === 'true' && !hasEnteredViewport;
+
+  if (didEnter) {
+    element.setAttribute('data-in-viewport-entered', true);
+    enterCallback();
+  }
+
+  if (didLeave && viewportSpy) {
+    element.setAttribute('data-in-viewport-entered', false);
+    exitCallback();
+  }
+
+  if (viewportSpy || !didEnter) {
+    return false;
+  }
+
+  return true;
 }

--- a/addon/-private/raf-admin.js
+++ b/addon/-private/raf-admin.js
@@ -11,7 +11,7 @@ export default class RAFAdmin {
   /** @private **/
   constructor() {
     this._rafPool = new RafPool();
-    this.registry = new WeakMap();
+    this.elementRegistry = new WeakMap();
   }
 
   add(...args) {
@@ -30,25 +30,50 @@ export default class RAFAdmin {
     this._rafPool.reset(...args);
   }
 
+  /**
+   * We provide our own element registry to add callbacks the user creates
+   *
+   * @method addEnterCallback
+   * @param {HTMLElement} element
+   * @param {Function} enterCallback
+   */
   addEnterCallback(element, enterCallback) {
-    this.registry.set(
+    this.elementRegistry.set(
       element,
-      Object.assign({}, this.registry.get(element), { enterCallback })
+      Object.assign({}, this.elementRegistry.get(element), { enterCallback })
     );
   }
 
+  /**
+   * We provide our own element registry to add callbacks the user creates
+   *
+   * @method addExitCallback
+   * @param {HTMLElement} element
+   * @param {Function} exitCallback
+   */
   addExitCallback(element, exitCallback) {
-    this.registry.set(
+    this.elementRegistry.set(
       element,
-      Object.assign({}, this.registry.get(element), { exitCallback })
+      Object.assign({}, this.elementRegistry.get(element), { exitCallback })
     );
   }
 
   getCallbacks(element) {
-    return this.registry.get(element);
+    return this.elementRegistry.get(element);
   }
 }
 
+/**
+ * This is a recursive function that adds itself to raf-pool to be executed on a set schedule
+ *
+ * @method startRAF
+ * @param {HTMLElement} element
+ * @param {Object} configurationOptions
+ * @param {Function} enterCallback
+ * @param {Function} exitCallback
+ * @param {Function} addRAF
+ * @param {Function} removeRAF
+ */
 export function startRAF(
   element,
   {

--- a/addon/-private/raf-admin.js
+++ b/addon/-private/raf-admin.js
@@ -89,6 +89,7 @@ export function startRAF(
 
     if (viewportSpy || viewportEntered !== 'true') {
       // recursive
+      // add to pool of requestAnimationFrame listeners and executed on set schedule
       addRAF(
         startRAF.bind(
           this,
@@ -119,14 +120,12 @@ function triggerDidEnterViewport(
     enterCallback();
   }
 
-  if (didLeave && viewportSpy) {
-    element.setAttribute('data-in-viewport-entered', false);
+  if (didLeave) {
     exitCallback();
-  }
 
-  if (viewportSpy || !didEnter) {
-    return false;
+    // reset so we can call again
+    if (viewportSpy) {
+      element.setAttribute('data-in-viewport-entered', false);
+    }
   }
-
-  return true;
 }

--- a/addon/-private/raf-admin.js
+++ b/addon/-private/raf-admin.js
@@ -58,7 +58,8 @@ export function startRAF(
   },
   enterCallback,
   exitCallback,
-  addRAF
+  addRAF, // bound function from service to add elementId to raf pool
+  removeRAF // bound function from service to remove elementId to raf pool
 ) {
   const domScrollableArea = scrollableArea ? document.querySelector(scrollableArea) : undefined;
 
@@ -100,6 +101,8 @@ export function startRAF(
           addRAF
         )
       );
+    } else {
+      removeRAF()
     }
   }
 }

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -120,20 +120,12 @@ export default Mixin.create({
     if (get(this, 'viewportUseIntersectionObserver')) {
       return scheduleOnce('afterRender', this, () => {
         const scrollableArea = get(this, 'scrollableArea');
-        const domScrollableArea = scrollableArea ? document.querySelector(scrollableArea) : undefined;
-
-        // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
-        // IntersectionObserver takes either a Document Element or null for `root`
-        const { top = 0, left = 0, bottom = 0, right = 0 } = get(this, 'viewportTolerance');
-        const observerOptions = {
-          root: domScrollableArea,
-          rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
-          threshold: get(this, 'intersectionThreshold')
-        };
+        const viewportTolerance = get(this, 'viewportTolerance');
+        const intersectionThreshold = get(this, 'intersectionThreshold');
 
         get(this, 'inViewport').watchElement(
           element,
-          observerOptions,
+          { intersectionThreshold, viewportTolerance, scrollableArea },
           bind(this, this._onEnterIntersection),
           bind(this, this._onExitIntersection)
         );

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -236,6 +236,7 @@ export default Mixin.create({
   /**
    * @method _triggerDidAccessViewport
    * @param hasEnteredViewport
+   * @param viewportEntered
    */
   _triggerDidAccessViewport(hasEnteredViewport = false, viewportEntered) {
     const isTearingDown = this.isDestroyed || this.isDestroying;

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -131,13 +131,13 @@ export default Mixin.create({
           threshold: get(this, 'intersectionThreshold')
         };
 
-        // create IntersectionObserver instance or add to existing
-        get(this, 'inViewport').setupIntersectionObserver(
+        get(this, 'inViewport').watchElement(
           element,
           observerOptions,
           bind(this, this._onEnterIntersection),
           bind(this, this._onExitIntersection)
-        );
+        )
+
       });
     } else {
       return scheduleOnce('afterRender', this, () => {
@@ -270,7 +270,6 @@ export default Mixin.create({
 
     if (triggeredEventName) {
       this.trigger(triggeredEventName);
-      // get(this, 'inViewport').triggerEvent(triggeredEventName);
     }
   },
 

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -273,7 +273,7 @@ export default Mixin.create({
   _unbindIfEntered(element) {
     if (get(this, 'viewportEntered')) {
       this._unbindListeners(element);
-      this.removeObserver('viewportEntered', this, this._unbindIfEntered);
+      this.removeObserver('viewportEntered', this, '_unbindIfEntered');
       set(this, 'viewportEntered', false);
     }
   },

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -136,8 +136,7 @@ export default Mixin.create({
           observerOptions,
           bind(this, this._onEnterIntersection),
           bind(this, this._onExitIntersection)
-        )
-
+        );
       });
     } else {
       return scheduleOnce('afterRender', this, () => {

--- a/addon/services/in-viewport.js
+++ b/addon/services/in-viewport.js
@@ -71,10 +71,16 @@ export default class InViewport extends Service {
             configOptions,
             enterCallback,
             exitCallback,
-            this.addRAF.bind(this, element.elementId)
+            this.addRAF.bind(this, element.elementId),
+            this.removeRAF.bind(this, element.elementId)
           );
         });
       }
+
+      return {
+        onEnter: this.addEnterCallback.bind(this, element),
+        onExit: this.addExitCallback.bind(this, element)
+      };
   }
 
   buildObserverOptions({ intersectionThreshold = 0, scrollableArea = null, viewportTolerance = {} }) {
@@ -170,6 +176,11 @@ export default class InViewport extends Service {
   }
 
   /** other **/
+  stop(target) {
+    this.unobserveIntersectionObserver(target);
+    this.removeRAF(target);
+  }
+
   destroy() {
     set(this, 'registry', null);
     get(this, 'observerAdmin').destroy();

--- a/addon/services/in-viewport.js
+++ b/addon/services/in-viewport.js
@@ -44,8 +44,8 @@ export default class InViewport extends Service {
    * @method watchElement
    * @param HTMLElement element
    * @param Object configOptions
-   * @param Function enterCallback
-   * @param Function exitCallback
+   * @param Function enterCallback - support mixin approach
+   * @param Function exitCallback - support mixin approach
    * @void
    */
   watchElement(element, configOptions = {}, enterCallback, exitCallback) {
@@ -63,7 +63,11 @@ export default class InViewport extends Service {
         });
       } else {
         scheduleOnce('afterRender', this, () => {
-          const { enterCallback = noop, exitCallback = noop } = get(this, 'rafAdmin').getCallbacks(element) || {};
+          // grab the user added callbacks when we enter/leave the element
+          const {
+            enterCallback = noop,
+            exitCallback = noop
+          } = get(this, 'rafAdmin').getCallbacks(element) || {};
           // this isn't using the same functions as the mixin case, but that is b/c it is a bit harder to unwind.
           // So just rewrote it with pure functions for now
           startRAF(
@@ -81,19 +85,6 @@ export default class InViewport extends Service {
         onEnter: this.addEnterCallback.bind(this, element),
         onExit: this.addExitCallback.bind(this, element)
       };
-  }
-
-  buildObserverOptions({ intersectionThreshold = 0, scrollableArea = null, viewportTolerance = {} }) {
-    const domScrollableArea = scrollableArea ? document.querySelector(scrollableArea) : undefined;
-
-    // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
-    // IntersectionObserver takes either a Document Element or null for `root`
-    const { top = 0, left = 0, bottom = 0, right = 0 } = viewportTolerance;
-    return {
-      root: domScrollableArea,
-      rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
-      threshold: intersectionThreshold
-    };
   }
 
   /**
@@ -152,6 +143,19 @@ export default class InViewport extends Service {
     );
   }
 
+  buildObserverOptions({ intersectionThreshold = 0, scrollableArea = null, viewportTolerance = {} }) {
+    const domScrollableArea = scrollableArea ? document.querySelector(scrollableArea) : undefined;
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+    // IntersectionObserver takes either a Document Element or null for `root`
+    const { top = 0, left = 0, bottom = 0, right = 0 } = viewportTolerance;
+    return {
+      root: domScrollableArea,
+      rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
+      threshold: intersectionThreshold
+    };
+  }
+
   unobserveIntersectionObserver(target) {
     if (!target) {
       return;
@@ -168,7 +172,7 @@ export default class InViewport extends Service {
   }
 
   removeRAF(elementId) {
-    get(this,'rafAdmin').remove(elementId);
+    get(this, 'rafAdmin').remove(elementId);
   }
 
   isInViewport(...args) {
@@ -194,5 +198,4 @@ export default class InViewport extends Service {
       return assign(defaultOptions, owner.lookup('config:in-viewport'));
     }
   }
-
 }

--- a/addon/services/in-viewport.js
+++ b/addon/services/in-viewport.js
@@ -1,6 +1,10 @@
 import Service from '@ember/service';
-import { get, set } from '@ember/object';
+import { get, set, setProperties } from '@ember/object';
+import { assign } from '@ember/polyfills';
+import { getOwner } from '@ember/application';
 import isInViewport from 'ember-in-viewport/utils/is-in-viewport';
+import canUseRAF from 'ember-in-viewport/utils/can-use-raf';
+import canUseIntersectionObserver from 'ember-in-viewport/utils/can-use-intersection-observer';
 import ObserverAdmin from 'ember-in-viewport/-private/observer-admin';
 import RAFAdmin from 'ember-in-viewport/-private/raf-admin';
 
@@ -17,19 +21,78 @@ export default class InViewport extends Service {
     this._super(...arguments);
 
     this.observerAdmin = new ObserverAdmin();
-    this._rAFAdmin = new RAFAdmin();
+    this.rafAdmin = new RAFAdmin();
     set(this, 'registry', new WeakMap());
+
+    let options = assign({
+      viewportUseRAF: canUseRAF()
+    }, this._buildOptions());
+
+    // set viewportUseIntersectionObserver after merging users config to avoid errors in browsers that lack support (https://github.com/DockYard/ember-in-viewport/issues/146)
+    options = assign(options, {
+      viewportUseIntersectionObserver: canUseIntersectionObserver(),
+    });
+
+    setProperties(this, options);
+  }
+
+  /** Any strategy **/
+
+  /**
+   * @method watchElement
+   * @param HTMLElement element
+   * @param Object observerOptions
+   * @param Function enterCallback
+   * @param Function exitCallback
+   * @void
+   */
+  watchElement(element, observerOptions, enterCallback, exitCallback) {
+    if (!observerOptions) {
+      this.buildObserverOptions();
+    }
+    if (get(this, 'viewportUseIntersectionObserver')) {
+      // create IntersectionObserver instance or add to existing
+      this.setupIntersectionObserver(
+        element,
+        observerOptions,
+        enterCallback,
+        exitCallback
+      );
+    }
+  }
+
+  buildObserverOptions() {
+    const scrollableArea = get(this, 'scrollableArea');
+    const domScrollableArea = scrollableArea ? document.querySelector(scrollableArea) : undefined;
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+    // IntersectionObserver takes either a Document Element or null for `root`
+    const { top = 0, left = 0, bottom = 0, right = 0 } = get(this, 'viewportTolerance');
+    return {
+      root: domScrollableArea,
+      rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
+      threshold: get(this, 'intersectionThreshold')
+    };
   }
 
   /**
-   * Trigger various events like didEnterViewport and didExitViewport
-   *
-   * @method triggerEvent
-   * @param String eventName
+   * @method addEnterCallback
    * @void
    */
-  triggerEvent(eventName) {
-    this.trigger(eventName);
+  addEnterCallback(element, enterCallback) {
+    if (get(this, 'viewportUseIntersectionObserver')) {
+      this.observerAdmin.addEnterCallback(element, enterCallback);
+    }
+  }
+
+  /**
+   * @method addExitCallback
+   * @void
+   */
+  addExitCallback(element, exitCallback) {
+    if (get(this, 'viewportUseIntersectionObserver')) {
+      this.observerAdmin.addExitCallback(element, exitCallback);
+    }
   }
 
   /** IntersectionObserver **/
@@ -75,11 +138,11 @@ export default class InViewport extends Service {
 
   /** RAF **/
   addRAF(elementId, callback) {
-    rAFIDS[elementId] = get(this, '_rAFAdmin').add(elementId, callback);
+    rAFIDS[elementId] = get(this, 'rafAdmin').add(elementId, callback);
   }
 
   removeRAF(elementId) {
-    get(this,'_rAFAdmin').remove(elementId);
+    get(this,'rafAdmin').remove(elementId);
     delete rAFIDS[elementId];
   }
 
@@ -91,6 +154,15 @@ export default class InViewport extends Service {
   destroy() {
     set(this, 'registry', null);
     get(this, 'observerAdmin').destroy();
-    get(this, '_rAFAdmin').reset();
+    get(this, 'rafAdmin').reset();
   }
+
+  _buildOptions(defaultOptions = {}) {
+    const owner = getOwner(this);
+
+    if (owner) {
+      return assign(defaultOptions, owner.lookup('config:in-viewport'));
+    }
+  }
+
 }

--- a/addon/services/in-viewport.js
+++ b/addon/services/in-viewport.js
@@ -64,6 +64,8 @@ export default class InViewport extends Service {
       } else {
         scheduleOnce('afterRender', this, () => {
           const { enterCallback = noop, exitCallback = noop } = get(this, 'rafAdmin').getCallbacks(element) || {};
+          // this isn't using the same functions as the mixin case, but that is b/c it is a bit harder to unwind.
+          // So just rewrote it with pure functions for now
           startRAF(
             element,
             configOptions,

--- a/addon/services/in-viewport.js
+++ b/addon/services/in-viewport.js
@@ -176,7 +176,7 @@ export default class InViewport extends Service {
   }
 
   /** other **/
-  stop(target) {
+  stopWatching(target) {
     this.unobserveIntersectionObserver(target);
     this.removeRAF(target);
   }

--- a/addon/services/in-viewport.js
+++ b/addon/services/in-viewport.js
@@ -41,15 +41,13 @@ export default class InViewport extends Service {
   /**
    * @method watchElement
    * @param HTMLElement element
-   * @param Object observerOptions
+   * @param Object configOptions
    * @param Function enterCallback
    * @param Function exitCallback
    * @void
    */
-  watchElement(element, observerOptions, enterCallback, exitCallback) {
-    if (!observerOptions) {
-      this.buildObserverOptions();
-    }
+  watchElement(element, configOptions = {}, enterCallback, exitCallback) {
+    const observerOptions = this.buildObserverOptions(configOptions);
     if (get(this, 'viewportUseIntersectionObserver')) {
       // create IntersectionObserver instance or add to existing
       this.setupIntersectionObserver(
@@ -61,17 +59,16 @@ export default class InViewport extends Service {
     }
   }
 
-  buildObserverOptions() {
-    const scrollableArea = get(this, 'scrollableArea');
+  buildObserverOptions({ intersectionThreshold = 0, scrollableArea = null, viewportTolerance = {} }) {
     const domScrollableArea = scrollableArea ? document.querySelector(scrollableArea) : undefined;
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
     // IntersectionObserver takes either a Document Element or null for `root`
-    const { top = 0, left = 0, bottom = 0, right = 0 } = get(this, 'viewportTolerance');
+    const { top = 0, left = 0, bottom = 0, right = 0 } = viewportTolerance;
     return {
       root: domScrollableArea,
       rootMargin: `${top}px ${right}px ${bottom}px ${left}px`,
-      threshold: get(this, 'intersectionThreshold')
+      threshold: intersectionThreshold
     };
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,19 @@
         "@babel/types": "^7.4.0"
       }
     },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.3.tgz",
+      "integrity": "sha512-UMl3TSpX11PuODYdWGrUeW6zFkdYhDn7wRLrOuNVM6f9L+S9CzmDXYyrp3MTHcwWjnzur1f/Op8A7iYZWya2Yg==",
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.4.0",
+        "@babel/helper-split-export-declaration": "^7.4.0"
+      }
+    },
     "@babel/helper-define-map": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
@@ -263,6 +276,25 @@
         "@babel/plugin-syntax-async-generators": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz",
+      "integrity": "sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.4.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-decorators": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.0.tgz",
+      "integrity": "sha512-d08TLmXeK/XbgCo7ZeZ+JaeZDtDai/2ctapTRsWWkkmy7G/cqz8DQN/HlWG7RR4YmfXxmExsbU3SuCjlM7AtUg==",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.4.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-decorators": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
@@ -337,6 +369,14 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
       "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-decorators": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
+      "integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -851,6 +891,35 @@
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
+      }
+    },
+    "@ember-decorators/component": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ember-decorators/component/-/component-6.0.0.tgz",
+      "integrity": "sha512-kdXZ+SV286vJ0l4ZJWK6ZbTApevebgSnLdi6++ld3H7uc7uI1XLGzxTIyp2/eFeclJlYiy/KnV0ElTAk35dPGQ==",
+      "dev": true,
+      "requires": {
+        "@ember-decorators/utils": "^6.0.0",
+        "ember-cli-babel": "^7.1.3"
+      }
+    },
+    "@ember-decorators/object": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ember-decorators/object/-/object-6.0.0.tgz",
+      "integrity": "sha512-VK4PT1fBZB0SPd+6f1YVyNw9PO5vK/wV05lIANVmvjE8SHP09ig1z04ajBujQMJtbQBFbTfwwnxtBAOfNUNr5g==",
+      "dev": true,
+      "requires": {
+        "@ember-decorators/utils": "^6.0.0",
+        "ember-cli-babel": "^7.1.3"
+      }
+    },
+    "@ember-decorators/utils": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ember-decorators/utils/-/utils-6.0.0.tgz",
+      "integrity": "sha512-moW4Oa7X1CN15LvjHlJVuwI4PpwTjXTPHPCCJll+a0X1sowQhObcLRykn6OMwdm9naCROGnRmcwpVqnE0eFjBg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.3"
       }
     },
     "@ember/optional-features": {
@@ -1659,6 +1728,147 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "babel-eslint": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
+      "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.44"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.44",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.2.0",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+          "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.44",
+            "@babel/template": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+          "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.44"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+          "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.44"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+          "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+          "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44",
+            "babylon": "7.0.0-beta.44",
+            "lodash": "^4.2.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+          "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.44",
+            "@babel/generator": "7.0.0-beta.44",
+            "@babel/helper-function-name": "7.0.0-beta.44",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44",
+            "babylon": "7.0.0-beta.44",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         }
       }
     },
@@ -4878,11 +5088,13 @@
       }
     },
     "ember-cli-babel": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.6.0.tgz",
-      "integrity": "sha512-2m400ZW9c4EE343g/j1U7beJgjJezTdDCgXM2koHdhpLlZB1Kz7iQw8S+t8gzXGwSGXlf7C7v0RHxP1/bo8frA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz",
+      "integrity": "sha512-/LWwyKIoSlZQ7k52P+6agC7AhcOBqPJ5C2u27qXHVVxKvCtg6ahNuRk/KmfZmV4zkuw4EjTZxfJE1PzpFyHkXg==",
       "requires": {
         "@babel/core": "^7.0.0",
+        "@babel/plugin-proposal-class-properties": "^7.3.4",
+        "@babel/plugin-proposal-decorators": "^7.3.0",
         "@babel/plugin-transform-modules-amd": "^7.0.0",
         "@babel/plugin-transform-runtime": "^7.2.0",
         "@babel/polyfill": "^7.0.0",
@@ -4897,6 +5109,7 @@
         "broccoli-funnel": "^2.0.1",
         "broccoli-source": "^1.1.0",
         "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.0",
         "ember-cli-version-checker": "^2.1.2",
         "ensure-posix-path": "^1.0.2",
         "semver": "^5.5.0"
@@ -4912,9 +5125,9 @@
           }
         },
         "babel-plugin-debug-macros": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.0.tgz",
-          "integrity": "sha512-D6qYBI/3+FvcKVnRnH6FBUwXPp/5o/jnJNVFKqVaZpYAWx88+R8jNNyaEX7iQFs7UfCib6rcY/9+ICR4jhjFCQ==",
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.1.tgz",
+          "integrity": "sha512-1tnO63L4d9HFHguR4Xc+/Y7Og1+mDsXwiStVrsayyXIDauv6r1o9dnhRKPmmCV5digG2XgScnQJpWDsxNNLU7g==",
           "requires": {
             "semver": "^5.3.0"
           }
@@ -5001,6 +5214,11 @@
           }
         }
       }
+    },
+    "ember-cli-babel-plugin-helpers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz",
+      "integrity": "sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA=="
     },
     "ember-cli-broccoli-sane-watcher": {
       "version": "3.0.0",
@@ -5216,6 +5434,50 @@
         "babel-plugin-debug-macros": "^0.2.0",
         "ember-cli-version-checker": "^2.1.1",
         "semver": "^5.4.1"
+      }
+    },
+    "ember-decorators": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-decorators/-/ember-decorators-6.0.0.tgz",
+      "integrity": "sha512-qzgaE3U/bwIIsogH3r3GGTgvQ85/BnKgoapWNgoKsGQIPxyVMbDXIdznNMmDm5JdXW/B/e9Wa3TzfNsPmimeAg==",
+      "dev": true,
+      "requires": {
+        "@ember-decorators/component": "^6.0.0",
+        "@ember-decorators/object": "^6.0.0",
+        "ember-cli-babel": "^7.7.3"
+      }
+    },
+    "ember-decorators-polyfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ember-decorators-polyfill/-/ember-decorators-polyfill-1.0.4.tgz",
+      "integrity": "sha512-GoCPwWX4x5Xqn6jwr2DaWS4bqjnpXlc4oGTXVWcn2Wh++ZE27yURr7ZRMEQROc8c4omndzlsrM83kTLSIq0XAA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-compatibility-helpers": "^1.2.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
+          }
+        },
+        "resolve-package-path": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.7.tgz",
+          "integrity": "sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.10.0"
+          }
+        }
       }
     },
     "ember-disable-prototype-extensions": {

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
   "license": "MIT",
   "dependencies": {
     "ember-auto-import": "^1.2.15",
-    "ember-cli-babel": "^7.1.2",
+    "ember-cli-babel": "^7.7.3",
     "intersection-observer-admin": "0.2.0",
     "raf-pool": "0.1.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
     "@ember/render-modifiers": "^1.0.0",
+    "babel-eslint": "^8.2.6",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.8.1",
     "ember-cli-dependency-checker": "^3.1.0",
@@ -39,6 +40,8 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.1.0",
+    "ember-decorators": "^6.0.0",
+    "ember-decorators-polyfill": "^1.0.4",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: 'babel-eslint',
   env: {
     embertest: true
   },

--- a/tests/acceptance/infinity-test.js
+++ b/tests/acceptance/infinity-test.js
@@ -28,14 +28,14 @@ module('Acceptance | infinity-scrollable', function(hooks) {
   test('ember-in-viewport works with classes', async function(assert) {
     await visit('/infinity-class');
 
-    assert.equal(findAll('.infinity-class-item').length, 10);
+    assert.equal(findAll('.infinity-class-item').length, 20);
     document.querySelector('#loader').scrollIntoView(false);
 
     await waitUntil(() => {
-      return findAll('.infinity-class-item').length === 20;
+      return findAll('.infinity-class-item').length === 40;
     });
 
-    assert.equal(findAll('.infinity-class-item').length, 20);
+    assert.equal(findAll('.infinity-class-item').length, 40);
   });
 
   test('IntersectionObserver Component fetches more data when left to right scrolling', async function(assert) {

--- a/tests/acceptance/infinity-test.js
+++ b/tests/acceptance/infinity-test.js
@@ -25,6 +25,19 @@ module('Acceptance | infinity-scrollable', function(hooks) {
     assert.equal(findAll('.infinity-svg').length, 20);
   });
 
+  test('ember-in-viewport works with classes', async function(assert) {
+    await visit('/infinity-class');
+
+    assert.equal(findAll('.infinity-class-item').length, 10);
+    document.querySelector('#loader').scrollIntoView(false);
+
+    await waitUntil(() => {
+      return findAll('.infinity-class-item').length === 20;
+    });
+
+    assert.equal(findAll('.infinity-class-item').length, 20);
+  });
+
   test('IntersectionObserver Component fetches more data when left to right scrolling', async function(assert) {
     await visit('/infinity-right-left');
 

--- a/tests/dummy/app/components/my-class-raf.js
+++ b/tests/dummy/app/components/my-class-raf.js
@@ -4,7 +4,7 @@ import { tagName } from '@ember-decorators/component';
 import { inject as service } from '@ember/service';
 
 @tagName('')
-export default class MyClass extends Component {
+export default class MyRafClass extends Component {
   @service inViewport
 
   didInsertElement() {

--- a/tests/dummy/app/components/my-class.js
+++ b/tests/dummy/app/components/my-class.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { get } from '@ember/object';
 import { tagName } from '@ember-decorators/component';
 import { inject as service } from '@ember/service';
 
@@ -8,8 +9,8 @@ export default class MyClass extends Component {
 
   didInsertElement() {
     const loader = document.getElementById('loader');
-    this.inViewport.watchElement(loader);
-    this.inViewport.addEnterCallback(loader, this.didEnterViewport.bind(this));
+    get(this, 'inViewport').watchElement(loader);
+    get(this, 'inViewport').addEnterCallback(loader, this.didEnterViewport.bind(this));
   }
 
   didEnterViewport() {

--- a/tests/dummy/app/components/my-class.js
+++ b/tests/dummy/app/components/my-class.js
@@ -1,0 +1,18 @@
+import Component from '@ember/component';
+import { inject } from '@ember/service';
+
+export default Component.extend({
+  inViewport: inject(),
+
+  tagName: '',
+
+  didInsertElement() {
+    const loader = document.getElementById('loader');
+    this.inViewport.watchElement(loader);
+    this.inViewport.addEnterCallback(loader, this.didEnterViewport.bind(this));
+  },
+
+  didEnterViewport() {
+    this.infinityLoad();
+  }
+});

--- a/tests/dummy/app/components/my-class.js
+++ b/tests/dummy/app/components/my-class.js
@@ -16,4 +16,9 @@ export default class MyClass extends Component {
   didEnterViewport() {
     this.infinityLoad();
   }
+
+  willDestroyElement() {
+    const loader = document.getElementById('loader');
+    this.inViewport.stopWatching(loader);
+  }
 }

--- a/tests/dummy/app/components/my-class.js
+++ b/tests/dummy/app/components/my-class.js
@@ -19,6 +19,6 @@ export default class MyClass extends Component {
 
   willDestroyElement() {
     const loader = document.getElementById('loader');
-    this.inViewport.stopWatching(loader);
+    get(this, 'inViewport').stopWatching(loader);
   }
 }

--- a/tests/dummy/app/components/my-class.js
+++ b/tests/dummy/app/components/my-class.js
@@ -9,8 +9,8 @@ export default class MyClass extends Component {
 
   didInsertElement() {
     const loader = document.getElementById('loader');
-    get(this, 'inViewport').addEnterCallback(loader, this.didEnterViewport.bind(this));
-    get(this, 'inViewport').watchElement(loader);
+    const { onEnter } = get(this, 'inViewport').watchElement(loader);
+    onEnter(this.didEnterViewport.bind(this));
   }
 
   didEnterViewport() {

--- a/tests/dummy/app/components/my-class.js
+++ b/tests/dummy/app/components/my-class.js
@@ -1,18 +1,18 @@
 import Component from '@ember/component';
-import { inject } from '@ember/service';
+import { tagName } from '@ember-decorators/component';
+import { inject as service } from '@ember/service';
 
-export default Component.extend({
-  inViewport: inject(),
-
-  tagName: '',
+@tagName('')
+export default class MyClass extends Component {
+  @service inViewport
 
   didInsertElement() {
     const loader = document.getElementById('loader');
     this.inViewport.watchElement(loader);
     this.inViewport.addEnterCallback(loader, this.didEnterViewport.bind(this));
-  },
+  }
 
   didEnterViewport() {
     this.infinityLoad();
   }
-});
+}

--- a/tests/dummy/app/controllers/infinity-class.js
+++ b/tests/dummy/app/controllers/infinity-class.js
@@ -1,0 +1,31 @@
+import Controller from '@ember/controller';
+import { set, get } from '@ember/object';
+
+let rect = '<rect x="10" y="10" width="30" height="30" stroke="black" fill="transparent" stroke-width="5"/>';
+let circle = '<circle cx="25" cy="75" r="20" stroke="red" fill="transparent" stroke-width="5"/>';
+let line = '<line x1="10" x2="50" y1="110" y2="150" stroke="orange" stroke-width="5"/>';
+
+const images = [rect, circle, line];
+const arr = Array.apply(null, Array(10));
+const models = [...arr.map(() => `${images[(Math.random() * images.length) | 0]}`)];
+
+export default Controller.extend({
+  init() {
+    this._super(...arguments);
+    this.viewportToleranceOverride = {
+      bottom: 200
+    }
+  },
+
+  models,
+
+  actions: {
+    infinityLoad() {
+      const arr = Array.apply(null, Array(10));
+      const newModels = [...arr.map(() => `${images[(Math.random() * images.length) | 0]}`)];
+      const models = get(this, 'models');
+      models.push(...newModels);
+      set(this, 'models', Array.prototype.slice.call(models));
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -13,6 +13,7 @@ Router.map(function() {
   this.route('infinity-scrollable-raf');
   this.route('infinity-scrollable-scrollevent');
   this.route('infinity-right-left');
+  this.route('infinity-class');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/infinity-class.js
+++ b/tests/dummy/app/routes/infinity-class.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -39,3 +39,11 @@ a.active {
   height: 10px;
 }
 
+.class-components {
+  display: flex;
+  justify-content: space-between;
+}
+
+#raf-loader {
+  height: 10px;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,6 +3,7 @@
 <ul>
   <li>{{link-to "Infinity IntersectionObserver" "infinity"}}</li>
   <li>{{link-to "Infinity with a Modifier" "infinity-modifier"}}</li>
+  <li>{{link-to "Infinity no Mixin" "infinity-class"}}</li>
   <li>{{link-to "Infinity Scrollable IntersectionObserver" "infinity-scrollable"}}</li>
   <li>{{link-to "Infinity Scrollable rAF" "infinity-scrollable-raf"}}</li>
   <li>{{link-to "Infinity Scrollable Event" "infinity-scrollable-scrollevent"}}</li>

--- a/tests/dummy/app/templates/components/my-class-raf.hbs
+++ b/tests/dummy/app/templates/components/my-class-raf.hbs
@@ -1,0 +1,1 @@
+<div id="raf-loader"></div>

--- a/tests/dummy/app/templates/components/my-class.hbs
+++ b/tests/dummy/app/templates/components/my-class.hbs
@@ -1,0 +1,1 @@
+<div id="loader"></div>

--- a/tests/dummy/app/templates/infinity-class.hbs
+++ b/tests/dummy/app/templates/infinity-class.hbs
@@ -1,0 +1,11 @@
+<ul>
+  {{#each models as |val|}}
+    <div class="infinity-class-item">
+      <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        {{{val}}}
+      </svg>
+    </div>
+  {{/each}}
+</ul>
+
+{{my-class infinityLoad=(action "infinityLoad")}}

--- a/tests/dummy/app/templates/infinity-class.hbs
+++ b/tests/dummy/app/templates/infinity-class.hbs
@@ -1,11 +1,29 @@
-<ul>
-  {{#each models as |val|}}
-    <div class="infinity-class-item">
-      <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
-        {{{val}}}
-      </svg>
-    </div>
-  {{/each}}
-</ul>
+<div class="class-components">
+  <div class="left">
+    <ul>
+      {{#each models as |val|}}
+        <div class="infinity-class-item">
+          <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            {{{val}}}
+          </svg>
+        </div>
+      {{/each}}
+    </ul>
 
-{{my-class infinityLoad=(action "infinityLoad")}}
+    {{my-class infinityLoad=(action "infinityLoad")}}
+  </div>
+
+  <div class="right">
+    <ul>
+      {{#each models as |val|}}
+        <div class="infinity-class-item">
+          <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            {{{val}}}
+          </svg>
+        </div>
+      {{/each}}
+    </ul>
+
+    {{my-class-raf infinityLoad=(action "infinityLoad")}}
+  </div>
+</div>

--- a/tests/dummy/app/templates/infinity-scrollable-raf.hbs
+++ b/tests/dummy/app/templates/infinity-scrollable-raf.hbs
@@ -1,11 +1,11 @@
 <div class="list-rAF infinity-container">
   <ul>
     {{#each model as |val|}}
-    <div class="infinity-svg-rAF">
-      <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
-        {{{val}}}
-      </svg>
-    </div>
+      <div class="infinity-svg-rAF">
+        <svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+          {{{val}}}
+        </svg>
+      </div>
     {{/each}}
   </ul>
   {{my-component


### PR DESCRIPTION
@gossi 👋 again!  This PR adds the ability to use classes if your target browser supports IntersectionObserver (e.g. not Safari).  I likely won't merge this until we can at least support rAF, but wanted to get your feedback first.  Thoughts on naming?

This PR adds three user facing APIs.

- `watchElement`
- `addEnterCallback`
- `addExitCallback`

```js
import Component from '@ember/component';
import { tagName } from '@ember-decorators/component';
import { inject as service } from '@ember/service'; // with polyfill

@tagName('')
export default class MyClass extends Component {
  @service inViewport

  didInsertElement() {
    const loader = document.getElementById('loader');
    const { didEnter } = this.inViewport.watchElement(loader);
    didEnter(this.didEnterViewport.bind(this));
  }

  didEnterViewport() {
    this.infinityLoad();
  }
}
```