### PR TITLE
No intersectionRatio in polyfill on prototype

### DIFF
--- a/addon/utils/can-use-intersection-observer.js
+++ b/addon/utils/can-use-intersection-observer.js
@@ -5,8 +5,7 @@ import canUseDOM from 'ember-in-viewport/utils/can-use-dom';
 
 function checkIntersectionObserver(window) {
   if ('IntersectionObserver' in window &&
-  'IntersectionObserverEntry' in window &&
-  'intersectionRatio' in window.IntersectionObserverEntry.prototype) {
+  'IntersectionObserverEntry' in window) {
 
     // Minimal polyfill for Edge 15's lack of `isIntersecting`
     // See: https://github.com/w3c/IntersectionObserver/issues/211


### PR DESCRIPTION
This will actually use the polyfill in safari if someone added it. 

https://raw.githubusercontent.com/w3c/IntersectionObserver/master/polyfill/intersection-observer.js

```js
ember-cli-build.js

app.import('vendor/intersection-observer-polyfill.js');
```