### PR TITLE
Fixing if condition with casting proper boolean

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -145,7 +145,7 @@ export default Mixin.create({
 
       const enterCallback = () => {
         const isTearingDown = this.isDestroyed || this.isDestroying;
-        const viewportEntered = JSON.parse(element.getAttribute('data-in-viewport-entered'));
+        const viewportEntered = element.getAttribute('data-in-viewport-entered') === "true";
         if (!isTearingDown && (viewportSpy || viewportEntered)) {
           set(this, 'viewportEntered', true);
           this.trigger('didEnterViewport');

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -145,7 +145,7 @@ export default Mixin.create({
 
       const enterCallback = () => {
         const isTearingDown = this.isDestroyed || this.isDestroying;
-        const viewportEntered = element.getAttribute('data-in-viewport-entered');
+        const viewportEntered = JSON.parse(element.getAttribute('data-in-viewport-entered'));
         if (!isTearingDown && viewportSpy || viewportEntered) {
           set(this, 'viewportEntered', true);
           this.trigger('didEnterViewport');

--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -146,7 +146,7 @@ export default Mixin.create({
       const enterCallback = () => {
         const isTearingDown = this.isDestroyed || this.isDestroying;
         const viewportEntered = JSON.parse(element.getAttribute('data-in-viewport-entered'));
-        if (!isTearingDown && viewportSpy || viewportEntered) {
+        if (!isTearingDown && (viewportSpy || viewportEntered)) {
           set(this, 'viewportEntered', true);
           this.trigger('didEnterViewport');
         }


### PR DESCRIPTION
It was recently happening to me on my acceptance test and failed them.
`if (!isTearingDown && viewportSpy || viewportEntered)` line evaulated wrongly because of         
`const viewportEntered = element.getAttribute('data-in-viewport-entered');` retrieve the boolean value in string.

When `isTearingDown` is `true` whole expression in the `if` (`!isTearingDown && viewportSpy || viewportEntered`) evaluated string `"true"` and casted non-empty string true.

So I cast the string boolean value properly in this PR.
