### PR TITLE
fixes #216, remove unnecessary call to startIntersectionObserver

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -122,8 +122,6 @@ export default Mixin.create({
     const inViewport = get(this, 'inViewport');
 
     if (get(this, 'viewportUseIntersectionObserver')) {
-      inViewport.startIntersectionObserver();
-
       return scheduleOnce('afterRender', this, () => {
         const scrollableArea = get(this, 'scrollableArea');
         const viewportTolerance = get(this, 'viewportTolerance');


### PR DESCRIPTION
Closes #216 

## Changes proposed in this pull request
The `in-viewport` service has a `startIntersectionObserver` function which creates an instance of `observerAdmin`. The `in-viewport` mixin has a call to `startIntersectionObserver` that does not check to see if `observerAdmin` already exists. This resulted in the single instance of `observerAdmin` inside the service being replaced every time a component using the mixin was created. `observerAdmin` has `WeakMap` "registry"s of `element` references that are useful to have access to when debugging issues using this addon, and the instance changing made that impossible to leverage.

The mixin's call to `startIntersectionObserver` proves to be unnecessary as it is immediately called inside `watchElement`. That call IS protected so that `observerAdmin` is only ever created once.

This PR removes the mixin's call to `startIntersectionObserver`.

Thanks, all!