### PR TITLE
Fixing in-viewport element modifier with rAF-based detection

### DIFF
--- a/addon/-private/raf-admin.js
+++ b/addon/-private/raf-admin.js
@@ -58,10 +58,6 @@ export default class RAFAdmin {
       Object.assign({}, this.elementRegistry.get(element), { exitCallback })
     );
   }
-
-  getCallbacks(element) {
-    return this.elementRegistry.get(element);
-  }
 }
 
 /**

--- a/addon/services/in-viewport.js
+++ b/addon/services/in-viewport.js
@@ -131,10 +131,6 @@ export default class InViewport extends Service {
     }
   }
 
-  getCallbacks(target) {
-    return this.rafAdmin.getCallbacks(target);
-  }
-
   /** IntersectionObserver **/
 
   /**

--- a/addon/services/in-viewport.js
+++ b/addon/services/in-viewport.js
@@ -85,11 +85,9 @@ export default class InViewport extends Service {
           return;
         }
 
-        // grab the user added callbacks when we enter/leave the element
-        const {
-          enterCallback = noop,
-          exitCallback = noop
-        } = this.getCallbacks(element) || {};
+        enterCallback = enterCallback || noop;
+        exitCallback = exitCallback || noop;
+
         // this isn't using the same functions as the mixin case, but that is b/c it is a bit harder to unwind.
         // So just rewrote it with pure functions for now
         startRAF(

--- a/tests/acceptance/infinity-test.js
+++ b/tests/acceptance/infinity-test.js
@@ -28,8 +28,28 @@ module('Acceptance | infinity-scrollable', function(hooks) {
   test('works with in-viewport modifier', async function(assert) {
     await visit('/infinity-built-in-modifiers');
 
-    // TODO: bring back (failing on 3.4)
-    // assert.equal(findAll('.infinity-item').length, 10, 'has items to start');
+    assert.equal(findAll('.infinity-item').length, 10, 'has items to start');
+
+    document.querySelector('.infinity-item-9').scrollIntoView(false);
+
+    await waitUntil(() => {
+      return findAll('.infinity-item').length === 20;
+    }, { timeoutMessage: 'did not find all items in time' });
+
+    await settled();
+
+    assert.equal(findAll('.infinity-item').length, 20, 'after infinity has more items');
+  });
+
+  test('works with in-viewport modifier (rAF)', async function(assert) {
+    let inViewportService = this.owner.lookup('service:in-viewport');
+
+    inViewportService.set('viewportUseIntersectionObserver', false);
+
+    await visit('/infinity-built-in-modifiers');
+
+    assert.equal(findAll('.infinity-item').length, 10, 'has items to start');
+
     document.querySelector('.infinity-item-9').scrollIntoView(false);
 
     await waitUntil(() => {

--- a/tests/dummy/app/components/dummy-artwork.js
+++ b/tests/dummy/app/components/dummy-artwork.js
@@ -75,13 +75,6 @@ export default class DummyArtwork extends Component {
     class;
 
     /**
-     * @property artworkProfile
-     * @type {String|Object}
-     * @public
-     */
-    artworkProfile;
-
-    /**
      * @property isDownloaded
      * @type {Boolean}
      * @default false

--- a/tests/dummy/app/controllers/infinity-built-in-modifiers.js
+++ b/tests/dummy/app/controllers/infinity-built-in-modifiers.js
@@ -4,26 +4,21 @@ import { action, set, get } from '@ember/object';
 
 const images = ['jarjan', 'aio___', 'kushsolitary', 'kolage', 'idiot', 'gt'];
 
-const arr = Array.apply(null, Array(10));
-const models = [
-  ...arr.map(() => {
-    return {
-      bgColor: 'E8D26F',
-      url: `https://s3.amazonaws.com/uifaces/faces/twitter/${
-        images[(Math.random() * images.length) | 0]
-      }/128.jpg`
-    };
-  })
-];
-
 export default class BuiltIn extends Controller {
   queryParams = ['direction'];
   direction = 'both';
 
-  init() {
-    super.init(...arguments);
+  constructor() {
+    super(...arguments);
 
-    this.models = models;
+    this.models = [...Array.apply(null, Array(10)).map(() => {
+      return {
+        bgColor: 'E8D26F',
+        url: `https://s3.amazonaws.com/uifaces/faces/twitter/${
+          images[(Math.random() * images.length) | 0]
+        }/128.jpg`
+      };
+    })];
     set(this, 'viewportTolerance', {
       bottom: 300
     });


### PR DESCRIPTION
Noticed that callbacks registered with the `in-viewport` element modifier were never being fired when the browser falls back to rAF-based detection. It seems that the enter and exit callbacks were always being set to noops when setting up elements to be watched.

Also found that the test controller was leaking the model state between tests, so fixed that up as well.

Thanks for the great addon! ❤️ 