### PR TITLE
Fix test failures in Ember 3.20: Run service teardown code in willDestroy()

### DIFF
--- a/addon/services/in-viewport.js
+++ b/addon/services/in-viewport.js
@@ -224,8 +224,7 @@ export default class InViewport extends Service {
     }
   }
 
-  destroy() {
-    super.destroy(...arguments);
+  willDestroy() {
     set(this, 'registry', null);
     if (this.observerAdmin) {
       this.observerAdmin.destroy();


### PR DESCRIPTION
Put the service teardown code in willDestroy() instead of destroy() so it runs at the expected time. destroy() schedules a call to willDestroy() on the run loop, so they happen at different times, and willDestroy() is the hook where teardown code is expected to live. Starting in Ember 3.20 having this code in destroy() can cause test teardown bugs if a modifier calls into the service to stop watching, because things happen in this order:

1. Service's destroy() method is called (by the container)
2. Modifiers' willRemove() hooks are called
3. Service's willDestroy() hook is called
    
So the service's teardown code needs to live in willDestroy() or else it will have already torn down by step (2) and calls into it from modifier teardown code can cause errors.

Note that I did not add any new tests as part of this PR because the existing tests are failing in the beta and (I'm pretty sure) canary scenarios, so this change already has test coverage.

Closes #240 