### PR TITLE
Passing intersection observer entry along to modifier callbacks

### DIFF
--- a/addon/modifiers/in-viewport.js
+++ b/addon/modifiers/in-viewport.js
@@ -39,14 +39,14 @@ export default class InViewportModifier extends Modifier {
   @action
   onEnter() {
     if (this.args.named.onEnter) {
-      this.args.named.onEnter.call(null, this.element);
+      this.args.named.onEnter.call(null, this.element, ...arguments);
     }
   }
 
   @action
   onExit() {
     if (this.args.named.onExit) {
-      this.args.named.onExit.call(null, this.element);
+      this.args.named.onExit.call(null, this.element, ...arguments);
     }
   }
 


### PR DESCRIPTION
I have a case where it would be beneficial to have the intersection observer entry in my `in-viewport` modifier callbacks.

```js
@action
entered(_, entry) {
    const targetInfo = entry.boundingClientRect;
    const rootBoundsInfo = entry.rootBounds;

    if (targetInfo.bottom < rootBoundsInfo.top) {
      // do some things
    }
}
```

```hbs
<div {{in-viewport onEnter=this.entered}}></div>
```