### PR TITLE
Intersection-Observer-Admin 0.2.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-babel": "^7.22.1",
     "ember-modifier": "^2.1.0",
     "fast-deep-equal": "^2.0.1",
-    "intersection-observer-admin": "~0.2.12",
+    "intersection-observer-admin": "~0.2.13",
     "raf-pool": "~0.1.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7361,10 +7361,10 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-intersection-observer-admin@~0.2.12:
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/intersection-observer-admin/-/intersection-observer-admin-0.2.12.tgz#046b208afc8cbf626943d61688d5a779c5831275"
-  integrity sha512-97+A29MV0kp6Xzkb4CxBNxxDU4qldyVFNzvZIiLMYqIZFutT2DJCzE1TEv0hXdmFQfAIY4KhNhL6L1BEEU0J8w==
+intersection-observer-admin@~0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/intersection-observer-admin/-/intersection-observer-admin-0.2.13.tgz#00a021695bf5aef8d198204514d2f849fd27d089"
+  integrity sha512-REIM59IHXPe9U5eTnowurzzfhgqVkSImZJnOSJZTAJ0LnyJqw8S/eD5s8ZYneQfm9JszhGIBwudF9gF02A3BpQ==
 
 into-stream@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
https://github.com/snewcomer/intersection-observer-admin/commit/aabb5790955b31dc7a0ae0f6e8d5e0ba408e5ea6

hasOwnProperty() should never be called from the object but from the generic prototype like is done in the commit above.