### PR TITLE
[Bug]: revert intersection-observer-admin bug with multiple elements sharing a single root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15732,9 +15732,9 @@
       "dev": true
     },
     "intersection-observer-admin": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/intersection-observer-admin/-/intersection-observer-admin-0.3.0.tgz",
-      "integrity": "sha512-S5CsK0o52tVJWGALZdk/sCAewWEQMLc2iemPjAnxmSwk/9Bul0PAQrjwX/KWg/xYN4nm3x/LgLOEPTNKEBlGyQ=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/intersection-observer-admin/-/intersection-observer-admin-0.3.1.tgz",
+      "integrity": "sha512-hMrk4pWMSAyx9sUIIeLI/oU/TuvItVh+BTpiDgQo+gAIhxWY62xiXmWfoHTDHdnRFzk7HBN+XrWPC4fKYBlI3Q=="
     },
     "into-stream": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-babel": "^7.26.3",
     "ember-modifier": "^2.1.0",
     "fast-deep-equal": "^2.0.1",
-    "intersection-observer-admin": "~0.3.0",
+    "intersection-observer-admin": "~0.3.1",
     "raf-pool": "~0.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
The fixes in the underlying library were due to test issues.  Unsure of the exact cause so far.  Reverting to give myself more time to investigate.

close https://github.com/snewcomer/intersection-observer-admin/issues/30

ref #271 