### PR TITLE
Fix deprecations caused by missing args to deprecate

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -71,6 +71,8 @@ export default Mixin.create({
       false,
       {
         id: 'ember-in-viewport.mixin',
+        for: 'ember-in-viewport',
+        since: '3.7.7',
         until: '4.0.0',
         url: 'https://github.com/DockYard/ember-in-viewport#readme',
       }


### PR DESCRIPTION
This fixes deprecations caused by missing args to `deprecate` function.

@snewcomer could you please release it as patch version before #281 lands which has breaking changes?