### PR TITLE
Fix options getter for in-viewport modifier so it returns correct object

### DIFF
--- a/addon/modifiers/in-viewport.js
+++ b/addon/modifiers/in-viewport.js
@@ -15,9 +15,7 @@ export default class InViewportModifier extends Modifier {
   lastOptions;
 
   get options() {
-    // eslint-disable-next-line no-unused-vars
-    const { onEnter, onExit, ...options } = this.args.named;
-    return options;
+    return this.args.named.options ?? {};
   }
 
   get hasStaleOptions() {


### PR DESCRIPTION
I found the `options` passed to the `in-viewport` modifier were being ignored.
Turns out if we run
```
const { onEnter, onExit, ...options } = this.args.named;
return options; // it returns { options: {} }
```
But we need it to return the contents of the options object.
You can check this on a simple example
```
const {...options } = { options: {foo: '42'}};
console.log(options); // logs {options: {…}}
// instead we want it to just log {foo: 42}
```